### PR TITLE
avendish-template: opt-in wasm input (sets up emsdk + emcmake build)

### DIFF
--- a/avendish-template/action.yml
+++ b/avendish-template/action.yml
@@ -2,10 +2,10 @@ name: 'Build Avendish template plugin'
 description: >
   Self-contained build for the celtera avendish-*-processor-template repos
   (audio / video / geometry). Fetches its own toolchain and SDKs (no ossia SDK):
-  Boost, Max, TouchDesigner, and optionally CLAP / VST3; godot-cpp is fetched by
-  CMake. Builds every Avendish back-end the project's CMakeLists emits, packages
-  each as a zip, and uploads them. Run once per OS from the caller's matrix
-  (Linux clang / Windows clang-cl / macOS).
+  Boost, Max, TouchDesigner, and optionally CLAP / VST3 / wasm (emsdk); godot-cpp
+  is fetched by CMake. Builds every Avendish back-end the project's CMakeLists
+  emits, packages each as a zip, and uploads them. Run once per OS from the
+  caller's matrix (Linux clang / Windows clang-cl / macOS).
 
 inputs:
   clap:
@@ -18,6 +18,10 @@ inputs:
     default: 'false'
   pd:
     description: 'Fetch PureData headers and build the Pd back-end (Linux/macOS; Windows needs pd.lib)'
+    required: false
+    default: 'false'
+  wasm:
+    description: 'Set up the Emscripten SDK and build the WebAssembly back-end (Linux only — runs as a separate `build-wasm` configure with `emcmake`).'
     required: false
     default: 'false'
   run-tests:
@@ -83,6 +87,12 @@ runs:
         repository: jcelerier/max-sdk-base
         submodules: 'recursive'
         path: max-sdk-base
+
+    - name: Set up Emscripten SDK
+      if: inputs.wasm == 'true' && runner.os == 'Linux'
+      uses: mymindstorm/setup-emsdk@v14
+      with:
+        version: 'latest'
 
     - name: Select Xcode 26 (macOS)
       if: runner.os == 'macOS'
@@ -214,6 +224,36 @@ runs:
             done
           )
         done
+
+    - name: Build wasm (emscripten)
+      if: inputs.wasm == 'true' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -e
+        BUILD_DIR=build-wasm
+        INSTALL_DIR="$PWD/install"
+        mkdir -p "$INSTALL_DIR"
+        export VERBOSE=1
+
+        emcmake cmake -S "$PWD" -B "$BUILD_DIR" -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBOOST_ROOT="$PWD/boost" \
+          -DBoost_NO_BOOST_CMAKE=ON \
+          -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
+          ${{ inputs.extra-cmake-args }}
+
+        cmake --build "$BUILD_DIR"
+
+        shopt -s nullglob
+        if [ -d "$BUILD_DIR/wasm" ]; then
+          (
+            cd "$BUILD_DIR/wasm"
+            for file in *; do
+              [ -e "$file" ] || continue
+              cmake -E tar cf "$INSTALL_DIR/wasm-wasm32-emscripten-$file.zip" --format=zip -- "$file"
+            done
+          )
+        fi
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Adds an opt-in `wasm: 'false'` input to the `avendish-template` composite action.
- When set to `'true'` on a Linux runner: installs the Emscripten SDK via [`mymindstorm/setup-emsdk@v14`](https://github.com/mymindstorm/setup-emsdk) and runs a separate \`emcmake cmake -S . -B build-wasm\` configure + build.
- Linux-only because emscripten output is wasm32 regardless of host; running it once per matrix-OS would produce identical artifacts under different triples.
- Wasm artifacts are zipped and published alongside the native ones, prefixed \`wasm-wasm32-emscripten-\`.

## Why

Avendish's wasm back-end (\`cmake/avendish.wasm.cmake\`) is gated on the \`EMSCRIPTEN\` variable — \`avnd_make_wasm\` is a no-op unless the whole configure runs under \`emcmake\`. Today the action only does one native configure, so no template-built addon publishes wasm artifacts. This adds the second configure dir without touching the native path.

## Test plan

- [ ] Caller workflow sets \`wasm: 'true'\`; verify the \`Set up Emscripten SDK\` and \`Build wasm (emscripten)\` steps run on the Linux job and stay skipped on Windows/macOS.
- [ ] Caller without \`wasm\` input gets the same artifacts as before (no behavior change).
- [ ] Wasm artifact zips land in the uploaded artifact tarball under \`wasm-wasm32-emscripten-*.zip\`.