### PR TITLE
add score-addon.yml reusable workflow (bundles dev/sdk/jit/release)

### DIFF
--- a/.github/workflows/score-addon.yml
+++ b/.github/workflows/score-addon.yml
@@ -1,0 +1,42 @@
+name: Score addon CI
+
+# One-line CI for an ossia score addon. Runs the four reusable workflows
+# `score-addon-puara` and other addons already chain together (dev / sdk /
+# jit builds, plus the tag-gated release upload), so that adopting the
+# full puara-style pipeline costs a single `uses:` entry in the addon's
+# own workflow.
+#
+# Caller workflow (`.github/workflows/builds.yaml` in the addon repo):
+#
+#   name: Build
+#   on:
+#     pull_request:
+#     push:
+#       branches: [master, main, dev, develop]
+#       tags: ['v*']
+#
+#   concurrency:
+#     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+#     cancel-in-progress: true
+#
+#   jobs:
+#     ci:
+#       uses: ossia/actions/.github/workflows/score-addon.yml@master
+#       secrets: inherit
+
+on:
+  workflow_call:
+
+jobs:
+  dev:
+    uses: ossia/actions/.github/workflows/builds-dev.yml@master
+    secrets: inherit
+  sdk:
+    uses: ossia/actions/.github/workflows/builds-sdk.yml@master
+    secrets: inherit
+  jit:
+    uses: ossia/actions/.github/workflows/jit.yml@master
+    secrets: inherit
+  release:
+    uses: ossia/actions/.github/workflows/release.yml@master
+    secrets: inherit

--- a/.github/workflows/score-addon.yml
+++ b/.github/workflows/score-addon.yml
@@ -1,10 +1,11 @@
 name: Score addon CI
 
-# One-line CI for an ossia score addon. Runs the four reusable workflows
-# `score-addon-puara` and other addons already chain together (dev / sdk /
-# jit builds, plus the tag-gated release upload), so that adopting the
-# full puara-style pipeline costs a single `uses:` entry in the addon's
-# own workflow.
+# One-line CI for an ossia score addon. Bundles the four reusable
+# workflows score-addon-puara and other addons chain together (dev /
+# sdk / jit builds + tag-gated release upload), so adopting the full
+# puara-style pipeline costs a single `uses:` entry. Each of the four
+# tracks defaults to `true` and can be turned off per addon via the
+# matching boolean input.
 #
 # Caller workflow (`.github/workflows/builds.yaml` in the addon repo):
 #
@@ -23,20 +24,48 @@ name: Score addon CI
 #     ci:
 #       uses: ossia/actions/.github/workflows/score-addon.yml@master
 #       secrets: inherit
+#       # with:
+#       #   jit: false      # opt out of one track
+#       #   release: false
 
 on:
   workflow_call:
+    inputs:
+      dev:
+        description: 'Run the dev build (score dev tree)'
+        required: false
+        default: true
+        type: boolean
+      sdk:
+        description: 'Run the SDK build (latest + continuous score SDK)'
+        required: false
+        default: true
+        type: boolean
+      jit:
+        description: 'Run the JIT build (score runtime-loadable artifact)'
+        required: false
+        default: true
+        type: boolean
+      release:
+        description: 'Run the release job (./release.sh + tag-gated upload)'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   dev:
+    if: inputs.dev
     uses: ossia/actions/.github/workflows/builds-dev.yml@master
     secrets: inherit
   sdk:
+    if: inputs.sdk
     uses: ossia/actions/.github/workflows/builds-sdk.yml@master
     secrets: inherit
   jit:
+    if: inputs.jit
     uses: ossia/actions/.github/workflows/jit.yml@master
     secrets: inherit
   release:
+    if: inputs.release
     uses: ossia/actions/.github/workflows/release.yml@master
     secrets: inherit


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/score-addon.yml\` — a single reusable workflow that chains the four existing reusable workflows an ossia/score addon typically wires together:

- \`builds-dev.yml\`
- \`builds-sdk.yml\`
- \`jit.yml\`
- \`release.yml\`

Addons currently inline all four — e.g. \`score-addon-puara/.github/workflows/builds.yaml\` lists each one separately. With this PR they can collapse to:

\`\`\`yaml
jobs:
  ci:
    uses: ossia/actions/.github/workflows/score-addon.yml@master
    secrets: inherit
\`\`\`

The trigger config (\`pull_request\`, branch filter, tag \`v*\`) and concurrency-cancel block stay in the addon's caller workflow so each addon can pick its own branch policy — the new file just centralizes the job chain.

## Why

- One-line CI for new score addons.
- Future additions (extra SDK flavour, new artifact job) get added in one place instead of having to be PR'd into every consumer.

## Test plan

- [ ] Caller workflow with \`uses: ossia/actions/.github/workflows/score-addon.yml@master\` triggers the same four jobs that \`score-addon-puara\` currently runs inline.
- [ ] \`secrets: inherit\` propagates through both call levels (workflow_call → workflow_call is supported up to four levels deep).
- [ ] No behavior change for existing addons that keep inlining the four jobs — this is purely additive.