### PR TITLE
jit: install libv4l-0 so the score AppImage launches on Linux

### DIFF
--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -33,6 +33,11 @@ jobs:
           version: "${{ matrix.version }}"
           extract-path: "./sdk"
 
+      # Runtime libs the score AppImage expects from the system.
+      - name: Install runtime dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libv4l-0
+
       - name: JIT compile test
         uses: ossia/actions/jit-compile@master
         with:


### PR DESCRIPTION
The JIT compile test runs the score AppImage, which fails on Linux with `libv4l2.so.0: cannot open shared object file`. Install libv4l-0 (provides libv4l2.so.0) before the test.