### PR TITLE
avnd-addon: drop ossia-sdk dep, inline per-backend SDK fetches

### DIFF
--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -225,10 +225,12 @@ jobs:
             PD_INCLUDE="$PWD/puredata/src"
             PD_LIBARG=()
           fi
+          # macOS ships bash 3.2 which errors on "${empty[@]}" under set -u;
+          # the ${arr[@]+"${arr[@]}"} idiom expands to nothing when empty.
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INCLUDE_PATH="$PD_INCLUDE" \
-            "${PD_LIBARG[@]}" \
+            ${PD_LIBARG[@]+"${PD_LIBARG[@]}"} \
             -DBOOST_ROOT="$PWD/boost" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
@@ -1211,7 +1213,7 @@ jobs:
             -DBOOST_ROOT="$PWD/boost" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
-            "${GST_LINKARGS[@]}" \
+            ${GST_LINKARGS[@]+"${GST_LINKARGS[@]}"} \
             -DAVND_ENABLE_GSTREAMER=ON
           cmake --build addon/build --config Release
       - name: Package gstreamer backend

--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -190,10 +190,24 @@ jobs:
         shell: bash
         run: choco install -y puredata jq zip ninja
       - name: Checkout PureData headers
+        if: runner.os != 'Windows'
         uses: actions/checkout@v4
         with:
           repository: pure-data/pure-data
           path: puredata
+      - name: Download Pd Windows binary (provides pd.lib)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # avendish.pd.cmake does find_library(PD_LIB NAMES pd) on Windows.
+          # The official Pd .msw.zip ships src/ headers + bin/pd.lib (the MSVC
+          # import lib), unlike the pure-data/pure-data git checkout which is
+          # source-only. Mirrors how libossia's ossia-pd provisions pd on Windows.
+          PD_VERSION="0.55-2"
+          curl -fsSL "http://msp.ucsd.edu/Software/pd-${PD_VERSION}.msw.zip" -o pd.zip
+          cmake -E tar xf pd.zip
+          echo "PD_WIN_ROOT=$PWD/pd-${PD_VERSION}" >> "$GITHUB_ENV"
       - name: Set up Boost
         shell: bash
         run: |
@@ -204,9 +218,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+            PD_INCLUDE="$PD_WIN_ROOT/src"
+            PD_LIBARG=(-DCMAKE_LIBRARY_PATH="$PD_WIN_ROOT/bin")
+          else
+            PD_INCLUDE="$PWD/puredata/src"
+            PD_LIBARG=()
+          fi
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INCLUDE_PATH="$PWD/puredata/src" \
+            -DCMAKE_INCLUDE_PATH="$PD_INCLUDE" \
+            "${PD_LIBARG[@]}" \
             -DBOOST_ROOT="$PWD/boost" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \

--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -1192,11 +1192,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          GST_LINKARGS=()
+          if [[ "${RUNNER_OS:-}" == "macOS" ]]; then
+            # Homebrew's pkg-config doesn't always propagate the keg -L path into
+            # CMake's PkgConfig:: imported target, so the linker can't find
+            # libgstsdp-1.0.dylib etc. Add brew's lib dir + the pkgconfig path
+            # explicitly. PKG_CONFIG_PATH covers libsoup@2 (keg-only).
+            BREW_PREFIX="$(brew --prefix)"
+            export PKG_CONFIG_PATH="$BREW_PREFIX/opt/libsoup@2/lib/pkgconfig:$BREW_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+            GST_LINKARGS=(
+              -DCMAKE_MODULE_LINKER_FLAGS="-L$BREW_PREFIX/lib"
+              -DCMAKE_SHARED_LINKER_FLAGS="-L$BREW_PREFIX/lib"
+              -DCMAKE_EXE_LINKER_FLAGS="-L$BREW_PREFIX/lib"
+            )
+          fi
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBOOST_ROOT="$PWD/boost" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
+            "${GST_LINKARGS[@]}" \
             -DAVND_ENABLE_GSTREAMER=ON
           cmake --build addon/build --config Release
       - name: Package gstreamer backend

--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -1256,9 +1256,12 @@ jobs:
           emcmake cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_INCLUDE_DIR="$PWD/boost/include" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+            -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH \
             -DAVND_ENABLE_WASM=ON
           cmake --build addon/build --config Release
       - name: Package wasm backend

--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -214,7 +214,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package pd backend
         id: package
-        uses: ossia/actions/package-pd-addon@master
+        uses: ossia/actions/package-pd-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -351,7 +351,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package max backend
         id: package
-        uses: ossia/actions/package-max-addon@master
+        uses: ossia/actions/package-max-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -541,7 +541,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package vst3 backend
         id: package
-        uses: ossia/actions/package-vst3-addon@master
+        uses: ossia/actions/package-vst3-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -627,7 +627,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package clap backend
         id: package
-        uses: ossia/actions/package-clap-addon@master
+        uses: ossia/actions/package-clap-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -698,7 +698,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package vintage backend
         id: package
-        uses: ossia/actions/package-vintage-addon@master
+        uses: ossia/actions/package-vintage-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -776,7 +776,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package touchdesigner backend
         id: package
-        uses: ossia/actions/package-touchdesigner-addon@master
+        uses: ossia/actions/package-touchdesigner-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -864,7 +864,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package python backend
         id: package
-        uses: ossia/actions/package-python-addon@master
+        uses: ossia/actions/package-python-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -944,7 +944,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package godot backend
         id: package
-        uses: ossia/actions/package-godot-addon@master
+        uses: ossia/actions/package-godot-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -1107,7 +1107,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package standalone backend
         id: package
-        uses: ossia/actions/package-standalone-addon@master
+        uses: ossia/actions/package-standalone-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -1179,7 +1179,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package gstreamer backend
         id: package
-        uses: ossia/actions/package-gstreamer-addon@master
+        uses: ossia/actions/package-gstreamer-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -1240,7 +1240,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package wasm backend
         id: package
-        uses: ossia/actions/package-wasm-addon@master
+        uses: ossia/actions/package-wasm-addon@drop-ossia-sdk-dep
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon

--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -178,7 +178,9 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq puredata-dev jq zip
+          sudo apt install -yqq gcc-14 g++-14 puredata-dev jq zip
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -250,7 +252,7 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq zip unzip
+          sudo apt install -yqq gcc-14 g++-14 zip unzip
       - name: Merge per-OS Pd artifacts
         shell: bash
         run: |
@@ -388,7 +390,7 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq zip unzip jq
+          sudo apt install -yqq gcc-14 g++-14 zip unzip jq
       - name: Merge per-OS Max artifacts
         shell: bash
         run: |
@@ -489,7 +491,9 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq libgl-dev libx11-dev libxcb1-dev jq zip
+          sudo apt install -yqq gcc-14 g++-14 libgl-dev libx11-dev libxcb1-dev jq zip
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -587,7 +591,9 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq libgl-dev libx11-dev jq zip
+          sudo apt install -yqq gcc-14 g++-14 libgl-dev libx11-dev jq zip
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -823,7 +829,9 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq python3-dev jq zip
+          sudo apt install -yqq gcc-14 g++-14 python3-dev jq zip
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -906,7 +914,9 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq libgl-dev jq zip
+          sudo apt install -yqq gcc-14 g++-14 libgl-dev jq zip
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -974,7 +984,7 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq zip unzip
+          sudo apt install -yqq gcc-14 g++-14 zip unzip
       - name: Merge per-OS Godot artifacts
         shell: bash
         run: |
@@ -1067,7 +1077,9 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq libgl-dev libx11-dev jq zip
+          sudo apt install -yqq gcc-14 g++-14 libgl-dev libx11-dev jq zip
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -1140,8 +1152,10 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+          sudo apt install -yqq gcc-14 g++-14 libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
             libglib2.0-dev libjson-glib-dev libsoup2.4-dev pkg-config jq zip
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
@@ -1202,7 +1216,9 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq jq zip
+          sudo apt install -yqq gcc-14 g++-14 jq zip
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v14
       - name: Set up Boost

--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -1159,7 +1159,7 @@ jobs:
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash
-        run: brew install gstreamer gst-plugins-base jq || true
+        run: brew install gstreamer gst-plugins-base json-glib libsoup@2 jq || true
       - name: Set up Boost
         shell: bash
         run: |
@@ -1236,6 +1236,7 @@ jobs:
             -DBOOST_ROOT="$PWD/boost" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
+            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
             -DAVND_ENABLE_WASM=ON
           cmake --build addon/build --config Release
       - name: Package wasm backend

--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -1140,7 +1140,8 @@ jobs:
         shell: bash
         run: |
           sudo apt -y update
-          sudo apt install -yqq libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev jq zip
+          sudo apt install -yqq libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
+            libglib2.0-dev libjson-glib-dev libsoup2.4-dev pkg-config jq zip
       - name: Install dependencies (macOS)
         if: runner.os == 'macOS'
         shell: bash

--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -140,7 +140,12 @@ on:
 # backend name, the matrix, and the -D flag passed to CMake.
 #
 # CMake flag convention (uppercase):  -DAVND_ENABLE_<BACKEND>=ON
-# TODO: align with avendish CMake flag naming once standardised upstream.
+#
+# Each per-backend job inlines its own SDK fetch (mirroring the proven
+# pattern in the `avendish-template/action.yml` composite action) so this
+# workflow works for addons whose dependencies.cmake just FetchContents
+# avendish (e.g. celtera/avendish-*-processor-template) without any need
+# for the ossia/score SDK bundle.
 
 jobs:
   # ---------------- pd ----------------
@@ -182,16 +187,27 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y puredata jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Checkout PureData headers
+        uses: actions/checkout@v4
+        with:
+          repository: pure-data/pure-data
+          path: puredata
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DCMAKE_INCLUDE_PATH="$PWD/puredata/src" \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_PD=ON
           cmake --build addon/build --config Release
       - name: Package pd backend
@@ -307,16 +323,28 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Checkout Max SDK
+        uses: actions/checkout@v4
+        with:
+          repository: jcelerier/max-sdk-base
+          submodules: recursive
+          path: max-sdk-base
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DAVND_MAXSDK_PATH="$PWD/max-sdk-base" \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_MAX=ON
           cmake --build addon/build --config Release
       - name: Package max backend
@@ -470,17 +498,42 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Checkout VST3 SDK
+        uses: actions/checkout@v4
+        with:
+          repository: steinbergmedia/vst3sdk
+          submodules: recursive
+          path: vst3sdk
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
+          EXTRA=()
+          # Xcode 26's SDK no longer transitively provides std::terminate to
+          # the VST3 SDK's threadchecker_mac.mm.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            EXTRA+=( "-DCMAKE_CXX_FLAGS=-include exception" )
+          fi
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
-            -DAVND_ENABLE_VST3=ON
+            -DVST3_SDK_ROOT="$PWD/vst3sdk" \
+            -DSMTG_ENABLE_VSTGUI_SUPPORT=OFF \
+            -DSMTG_ADD_VSTGUI=OFF \
+            -DSMTG_CREATE_PLUGIN_LINK=OFF \
+            -DSMTG_RUN_VST_VALIDATOR=OFF \
+            -DSMTG_ENABLE_VST3_PLUGIN_EXAMPLES=OFF \
+            -DSMTG_ENABLE_VST3_HOSTING_EXAMPLES=OFF \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
+            -DAVND_ENABLE_VST3=ON \
+            "${EXTRA[@]}"
           cmake --build addon/build --config Release
       - name: Package vst3 backend
         id: package
@@ -543,16 +596,27 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Checkout CLAP SDK
+        uses: actions/checkout@v4
+        with:
+          repository: free-audio/clap
+          path: clap-sdk
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DCMAKE_PREFIX_PATH="$PWD/clap-sdk" \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_CLAP=ON
           cmake --build addon/build --config Release
       - name: Package clap backend
@@ -609,16 +673,21 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_VINTAGE=ON
           cmake --build addon/build --config Release
       - name: Package vintage backend
@@ -675,16 +744,28 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Checkout TouchDesigner SDK headers
+        uses: actions/checkout@v4
+        with:
+          repository: jcelerier/CustomOperatorSamples
+          ref: add-pop-headers
+          path: touchdesigner-sdk
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DTOUCHDESIGNER_SDK_PATH="$PWD/touchdesigner-sdk" \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_TOUCHDESIGNER=ON
           cmake --build addon/build --config Release
       - name: Package touchdesigner backend
@@ -751,16 +832,26 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Install pybind11
+        shell: bash
+        run: python -m pip install --upgrade pip pybind11
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DPython_EXECUTABLE="$(python -c 'import sys; print(sys.executable)')" \
+            -Dpybind11_DIR="$(python -m pybind11 --cmakedir)" \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_PYTHON=ON
           cmake --build addon/build --config Release
       - name: Package python backend
@@ -824,16 +915,21 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_GODOT=ON
           cmake --build addon/build --config Release
       - name: Package godot backend
@@ -980,16 +1076,21 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: choco install -y jq zip ninja
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_STANDALONE=ON
           cmake --build addon/build --config Release
       - name: Package standalone backend
@@ -1044,16 +1145,21 @@ jobs:
         if: runner.os == 'macOS'
         shell: bash
         run: brew install gstreamer gst-plugins-base jq || true
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_GSTREAMER=ON
           cmake --build addon/build --config Release
       - name: Package gstreamer backend
@@ -1098,16 +1204,21 @@ jobs:
           sudo apt install -yqq jq zip
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v14
-      - name: Download OSSIA SDK
-        id: ossia-sdk
-        uses: ossia/actions/download-ossia-sdk@master
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
       - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
           emcmake cmake -S addon -B addon/build \
             -DCMAKE_BUILD_TYPE=Release \
-            -DOSSIA_SDK=${{ steps.ossia-sdk.outputs.sdk-path }} \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DAVND_ENABLE_WASM=ON
           cmake --build addon/build --config Release
       - name: Package wasm backend

--- a/.github/workflows/avnd-portability.yml
+++ b/.github/workflows/avnd-portability.yml
@@ -316,8 +316,10 @@ jobs:
           set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
           set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
           set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-          set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-          set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+          # PACKAGE/INCLUDE = BOTH so find_package(Avendish) + Boost headers
+          # (fetched on the host side, not in the mingw sysroot) are visible.
+          set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+          set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)
           EOF
       - name: Set up Boost
         shell: bash
@@ -354,7 +356,7 @@ jobs:
         with:
           usesh: true
           prepare: |
-            pkg install -y cmake ninja boost-libs
+            pkg install -y cmake ninja boost-libs git
           run: |
             set -e
             cmake -S . -B build -G Ninja \
@@ -486,8 +488,12 @@ jobs:
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
             -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED=NO \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="" \
             -DCMAKE_CXX_FLAGS="-Werror=return-type"
-          cmake --build build --config Release -- -quiet
+          # No code signing in CI — this is a compile-only portability check.
+          cmake --build build --config Release -- -quiet CODE_SIGNING_ALLOWED=NO
 
   # ---------------- esp32 ----------------
   esp32:

--- a/.github/workflows/avnd-portability.yml
+++ b/.github/workflows/avnd-portability.yml
@@ -6,12 +6,14 @@
 # addons are "plain C++ classes with introspection", so portability is a
 # correctness property worth gating in CI.
 #
-# The build target is avendish's `dump` backend: a minimal introspection
-# executable produced via `avnd_make_dump` that links nothing
-# platform-specific. For each enabled lane, this workflow configures the
-# addon with `-DAVND_BUILD_PORTABILITY=ON -DAVND_DISABLE_DEFAULT_BACKENDS=ON`
-# and builds `dump_<addon-name>` - that's it, no packaging, no upload, no
-# test execution. A failed compile fails the job.
+# The build target is avendish's SDK-free portability surface. Each
+# avendish per-backend CMake module self-skips (stubs out its
+# `avnd_make_<backend>` function) when that backend's plugin SDK isn't
+# present. So for each enabled lane this workflow fetches NO plugin SDKs,
+# configures the addon, and builds everything: only the SDK-free targets
+# compile - the addon static lib, `<C_NAME>_dump`, and
+# `<C_NAME>_example_host`. That's it, no packaging, no upload, no test
+# execution. A failed compile fails the job.
 #
 # Usage in a caller repository (.github/workflows/builds.yaml):
 #
@@ -118,12 +120,15 @@ on:
 # jobs below are intentionally near-identical and mostly differ only in the
 # toolchain install + the CMake configure flags.
 #
-# CMake invocation convention (uppercase):
-#   cmake -S . -B build \
-#     -DAVND_BUILD_PORTABILITY=ON \
-#     -DAVND_DISABLE_DEFAULT_BACKENDS=ON
-#   cmake --build build --target dump_${addon} -j 4
-# TODO: align CMake target name with avendish convention once finalized.
+# CMake invocation convention:
+#   - Fetch no plugin SDKs and pass no backend-enable flags.
+#   - Provide Boost headers (the addon's find_package(Avendish) pulls in
+#     find_dependency(Boost), so configure fails without them).
+#   - Build everything (no --target): avendish self-skips every backend
+#     whose SDK is absent, so only the SDK-free dump + example_host
+#     targets actually compile.
+#       cmake -S . -B build -DBOOST_ROOT=... -DBoost_NO_BOOST_CMAKE=ON
+#       cmake --build build -j 4
 
 jobs:
   # ---------------- linux_gcc ----------------
@@ -146,19 +151,24 @@ jobs:
         run: |
           sudo apt -y update
           sudo apt install -yqq cmake ninja-build ${{ matrix.pkg }}
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
+      - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
-          ADDON="${{ github.event.repository.name }}"
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
-            -DAVND_BUILD_PORTABILITY=ON \
-            -DAVND_DISABLE_DEFAULT_BACKENDS=ON \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_CXX_FLAGS="-Werror=return-type -fsanitize=address -fsanitize=undefined -D_GLIBCXX_DEBUG=1 -D_GLIBCXX_DEBUG_PEDANTIC=1 -D_GLIBCXX_ASSERTIONS=1"
-          cmake --build build --target "dump_${ADDON}" -j 4
+          cmake --build build -j 4
 
   # ---------------- linux_clang ----------------
   linux_clang:
@@ -187,19 +197,24 @@ jobs:
           if [[ "${{ matrix.stdlib }}" == "libc++" ]]; then
             sudo apt install -yqq libc++-20-dev libc++abi-20-dev
           fi
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
+      - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
-          ADDON="${{ github.event.repository.name }}"
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER=clang++-20 \
-            -DAVND_BUILD_PORTABILITY=ON \
-            -DAVND_DISABLE_DEFAULT_BACKENDS=ON \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_CXX_FLAGS="${{ matrix.extra_flags }} -Werror=return-type -fsanitize=address -fsanitize=undefined -D_GLIBCXX_DEBUG=1 -D_GLIBCXX_DEBUG_PEDANTIC=1 -D_GLIBCXX_ASSERTIONS=1"
-          cmake --build build --target "dump_${ADDON}" -j 4
+          cmake --build build -j 4
 
   # ---------------- macos ----------------
   macos:
@@ -222,18 +237,23 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: brew install cmake ninja || true
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
+      - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
-          ADDON="${{ github.event.repository.name }}"
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DAVND_BUILD_PORTABILITY=ON \
-            -DAVND_DISABLE_DEFAULT_BACKENDS=ON \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_CXX_FLAGS="-Werror=return-type"
-          cmake --build build --target "dump_${ADDON}" -j 4
+          cmake --build build -j 4
 
   # ---------------- windows_msvc ----------------
   windows_msvc:
@@ -253,17 +273,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
+      - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
-          ADDON="${{ github.event.repository.name }}"
           # MSVC does not ship ASan/UBSan for the avendish path; skip sanitizers.
           cmake -S . -B build \
-            -DAVND_BUILD_PORTABILITY=ON \
-            -DAVND_DISABLE_DEFAULT_BACKENDS=ON
-          cmake --build build --config Release --target "dump_${ADDON}" -j 4
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD
+          cmake --build build --config Release -j 4
 
   # ---------------- windows_mingw ----------------
   windows_mingw:
@@ -294,19 +319,26 @@ jobs:
           set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
           set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
           EOF
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
+      - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
-          ADDON="${{ github.event.repository.name }}"
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE=$(pwd)/mingw-toolchain.cmake \
-            -DAVND_BUILD_PORTABILITY=ON \
-            -DAVND_DISABLE_DEFAULT_BACKENDS=ON \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
+            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
             -DCMAKE_CXX_FLAGS="-Werror=return-type"
-          cmake --build build --target "dump_${ADDON}" -j 4
+          cmake --build build -j 4
 
   # ---------------- freebsd ----------------
   freebsd:
@@ -317,8 +349,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target in FreeBSD VM
+      - name: Configure & build in FreeBSD VM
         uses: vmactions/freebsd-vm@v1
         with:
           usesh: true
@@ -326,13 +357,13 @@ jobs:
             pkg install -y cmake ninja boost-libs
           run: |
             set -e
-            ADDON="${{ github.event.repository.name }}"
             cmake -S . -B build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
-              -DAVND_BUILD_PORTABILITY=ON \
-              -DAVND_DISABLE_DEFAULT_BACKENDS=ON \
+              -DBOOST_ROOT=/usr/local \
+              -DBoost_NO_BOOST_CMAKE=ON \
+              -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
               -DCMAKE_CXX_FLAGS="-Werror=return-type"
-            cmake --build build --target "dump_${ADDON}" -j 4
+            cmake --build build -j 4
 
   # ---------------- wasm ----------------
   wasm:
@@ -350,17 +381,26 @@ jobs:
           sudo apt install -yqq cmake ninja-build
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v14
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
+      - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
-          ADDON="${{ github.event.repository.name }}"
           emcmake cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DAVND_BUILD_PORTABILITY=ON \
-            -DAVND_DISABLE_DEFAULT_BACKENDS=ON
-          cmake --build build --target "dump_${ADDON}" -j 4
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_INCLUDE_DIR="$PWD/boost/include" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
+            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+            -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH
+          cmake --build build -j 4
 
   # ---------------- android ----------------
   android:
@@ -387,21 +427,29 @@ jobs:
         run: |
           sudo apt -y update
           sudo apt install -yqq cmake ninja-build
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
+      - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
-          ADDON="${{ github.event.repository.name }}"
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
             -DANDROID_ABI=arm64-v8a \
             -DANDROID_PLATFORM=android-30 \
-            -DAVND_BUILD_PORTABILITY=ON \
-            -DAVND_DISABLE_DEFAULT_BACKENDS=ON \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_INCLUDE_DIR="$PWD/boost/include" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
+            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
             -DCMAKE_CXX_FLAGS="-Werror=return-type"
-          cmake --build build --target "dump_${ADDON}" -j 4
+          cmake --build build -j 4
 
   # ---------------- ios ----------------
   ios:
@@ -418,20 +466,28 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: brew install cmake ninja || true
-      # TODO: align CMake target name with avendish convention once finalized
-      - name: Configure & build dump target
+      - name: Set up Boost
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/ossia/score-sdk/releases/download/sdk31/boost_1_90_0.tar.gz -o boost.tar.gz
+          mkdir -p boost/include
+          tar -xzf boost.tar.gz --strip-components=1 -C boost/include
+      - name: Configure & build
         shell: bash
         run: |
           set -euo pipefail
-          ADDON="${{ github.event.repository.name }}"
           cmake -S . -B build -GXcode \
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_XCODE_EFFECTIVE_PLATFORMS=-iphoneos \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
-            -DAVND_BUILD_PORTABILITY=ON \
-            -DAVND_DISABLE_DEFAULT_BACKENDS=ON \
+            -DBOOST_ROOT="$PWD/boost" \
+            -DBoost_INCLUDE_DIR="$PWD/boost/include" \
+            -DBoost_NO_BOOST_CMAKE=ON \
+            -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
+            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+            -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
             -DCMAKE_CXX_FLAGS="-Werror=return-type"
-          cmake --build build --target "dump_${ADDON}" -- -quiet
+          cmake --build build --config Release -- -quiet
 
   # ---------------- esp32 ----------------
   esp32:

--- a/.github/workflows/avnd-portability.yml
+++ b/.github/workflows/avnd-portability.yml
@@ -121,12 +121,25 @@ on:
 # toolchain install + the CMake configure flags.
 #
 # CMake invocation convention:
-#   - Fetch no plugin SDKs and pass no backend-enable flags.
+#   - Fetch no plugin SDKs and explicitly disable every backend via
+#     ${AVND_OFF} (AVND_ENABLE_<X>=OFF). Some backends self-provision their
+#     deps (godot fetches godot-cpp, wasm uses embind) and would otherwise
+#     build even with no SDK present — and fail to cross-compile on exotic
+#     targets. Disabling them all leaves just the plain-C++ dump +
+#     example_host targets, which IS the portability surface.
 #   - Provide Boost headers (the addon's find_package(Avendish) pulls in
 #     find_dependency(Boost), so configure fails without them).
-#   - Build everything (no --target): avendish self-skips every backend
-#     whose SDK is absent, so only the SDK-free dump + example_host
-#     targets actually compile.
+#   - Build everything (no --target): with all backends off, only dump +
+#     example_host remain.
+
+env:
+  # Disable every plugin backend so the portability build is pure C++.
+  AVND_OFF: >-
+    -DAVND_ENABLE_PD=OFF -DAVND_ENABLE_MAX=OFF -DAVND_ENABLE_VST3=OFF
+    -DAVND_ENABLE_CLAP=OFF -DAVND_ENABLE_VINTAGE=OFF
+    -DAVND_ENABLE_TOUCHDESIGNER=OFF -DAVND_ENABLE_PYTHON=OFF
+    -DAVND_ENABLE_GODOT=OFF -DAVND_ENABLE_STANDALONE=OFF
+    -DAVND_ENABLE_GSTREAMER=OFF -DAVND_ENABLE_WASM=OFF
 #       cmake -S . -B build -DBOOST_ROOT=... -DBoost_NO_BOOST_CMAKE=ON
 #       cmake --build build -j 4
 
@@ -164,7 +177,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
-            -DBOOST_ROOT="$PWD/boost" \
+            -DBOOST_ROOT="$PWD/boost" ${AVND_OFF} \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_CXX_FLAGS="-Werror=return-type -fsanitize=address -fsanitize=undefined -D_GLIBCXX_DEBUG=1 -D_GLIBCXX_DEBUG_PEDANTIC=1 -D_GLIBCXX_ASSERTIONS=1"
@@ -210,7 +223,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DCMAKE_CXX_COMPILER=clang++-20 \
-            -DBOOST_ROOT="$PWD/boost" \
+            -DBOOST_ROOT="$PWD/boost" ${AVND_OFF} \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_CXX_FLAGS="${{ matrix.extra_flags }} -Werror=return-type -fsanitize=address -fsanitize=undefined -D_GLIBCXX_DEBUG=1 -D_GLIBCXX_DEBUG_PEDANTIC=1 -D_GLIBCXX_ASSERTIONS=1"
@@ -249,7 +262,7 @@ jobs:
           set -euo pipefail
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DBOOST_ROOT="$PWD/boost" \
+            -DBOOST_ROOT="$PWD/boost" ${AVND_OFF} \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_CXX_FLAGS="-Werror=return-type"
@@ -285,7 +298,7 @@ jobs:
           set -euo pipefail
           # MSVC does not ship ASan/UBSan for the avendish path; skip sanitizers.
           cmake -S . -B build \
-            -DBOOST_ROOT="$PWD/boost" \
+            -DBOOST_ROOT="$PWD/boost" ${AVND_OFF} \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD
           cmake --build build --config Release -j 4
@@ -334,7 +347,7 @@ jobs:
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE=$(pwd)/mingw-toolchain.cmake \
-            -DBOOST_ROOT="$PWD/boost" \
+            -DBOOST_ROOT="$PWD/boost" ${AVND_OFF} \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
             -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
@@ -362,6 +375,11 @@ jobs:
             cmake -S . -B build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DBOOST_ROOT=/usr/local \
+              -DAVND_ENABLE_PD=OFF -DAVND_ENABLE_MAX=OFF -DAVND_ENABLE_VST3=OFF \
+              -DAVND_ENABLE_CLAP=OFF -DAVND_ENABLE_VINTAGE=OFF \
+              -DAVND_ENABLE_TOUCHDESIGNER=OFF -DAVND_ENABLE_PYTHON=OFF \
+              -DAVND_ENABLE_GODOT=OFF -DAVND_ENABLE_STANDALONE=OFF \
+              -DAVND_ENABLE_GSTREAMER=OFF -DAVND_ENABLE_WASM=OFF \
               -DBoost_NO_BOOST_CMAKE=ON \
               -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
               -DCMAKE_CXX_FLAGS="-Werror=return-type"
@@ -395,7 +413,7 @@ jobs:
           set -euo pipefail
           emcmake cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DBOOST_ROOT="$PWD/boost" \
+            -DBOOST_ROOT="$PWD/boost" ${AVND_OFF} \
             -DBoost_INCLUDE_DIR="$PWD/boost/include" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
@@ -444,7 +462,7 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
             -DANDROID_ABI=arm64-v8a \
             -DANDROID_PLATFORM=android-30 \
-            -DBOOST_ROOT="$PWD/boost" \
+            -DBOOST_ROOT="$PWD/boost" ${AVND_OFF} \
             -DBoost_INCLUDE_DIR="$PWD/boost/include" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \
@@ -482,7 +500,7 @@ jobs:
             -DCMAKE_SYSTEM_NAME=iOS \
             -DCMAKE_XCODE_EFFECTIVE_PLATFORMS=-iphoneos \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=15.0 \
-            -DBOOST_ROOT="$PWD/boost" \
+            -DBOOST_ROOT="$PWD/boost" ${AVND_OFF} \
             -DBoost_INCLUDE_DIR="$PWD/boost/include" \
             -DBoost_NO_BOOST_CMAKE=ON \
             -DCMAKE_POLICY_DEFAULT_CMP0167=OLD \

--- a/package-clap-addon/action.yml
+++ b/package-clap-addon/action.yml
@@ -97,7 +97,7 @@ runs:
           echo "Copying CLAP plugin: $plugin"
           cp -R "$plugin" "$CLAP_STAGING_ABS/"
           FOUND=$((FOUND + 1))
-        done < <(find "$BUILD_CLAP_DIR" -maxdepth 1 -name '*.clap' -print0)
+        done < <(find "$BUILD_CLAP_DIR" -maxdepth 2 -name '*.clap' -print0)
 
         if [[ $FOUND -eq 0 ]]; then
           echo "Error: no .clap plugins found in $BUILD_CLAP_DIR"

--- a/package-godot-addon/action.yml
+++ b/package-godot-addon/action.yml
@@ -114,16 +114,21 @@ runs:
           exit 1
         fi
 
-        # 2. Copy every binary (loose .so / .dylib / .dll) into bin/<os>-<arch>/.
+        # 2. Copy every binary into bin/<os>-<arch>/. On macOS avendish emits a
+        #    .framework BUNDLE directory (codesign + staple friendly); on Linux/Windows
+        #    it's a flat .so/.dll. cp -R handles both.
         BIN_COUNT=0
         while IFS= read -r -d '' bin; do
           echo "Copying binary: $bin -> $GD_BIN_DIR/"
-          cp -f "$bin" "$GD_BIN_DIR/"
+          cp -R "$bin" "$GD_BIN_DIR/"
           BIN_COUNT=$((BIN_COUNT + 1))
-        done < <(find "$GD_SRC" -maxdepth 2 -type f \( -name '*.so' -o -name '*.dylib' -o -name '*.dll' \) -print0)
+        done < <(find "$GD_SRC" -maxdepth 2 \( \
+                     \( -type f \( -name '*.so' -o -name '*.dylib' -o -name '*.dll' \) \) \
+                  -o \( -type d -name '*.framework' \) \
+                 \) -print0)
 
         if [[ "$BIN_COUNT" -eq 0 ]]; then
-          echo "Error: no Godot binaries (.so/.dylib/.dll) found under '$GD_SRC'"
+          echo "Error: no Godot binaries (.so/.dylib/.dll/.framework) found under '$GD_SRC'"
           exit 1
         fi
         echo "Collected $CFG_COUNT gdextension config(s) and $BIN_COUNT binary/binaries."

--- a/package-gstreamer-addon/action.yml
+++ b/package-gstreamer-addon/action.yml
@@ -110,7 +110,7 @@ runs:
               cp -f "$plugin" "$GST_STAGING_ABS/"
               FOUND=$((FOUND + 1))
             done < <(find "$BUILD_GST_DIR" -maxdepth 2 -type f \
-                       \( -name 'lib*.so' -o -name 'lib*.so.*' \) -print0)
+                       \( -name '*.so' -o -name '*.so.*' \) -print0)
             ;;
           macos)
             # macOS MODULE libs can land as either lib*.so (CMake default) or
@@ -124,7 +124,7 @@ runs:
               cp -f "$plugin" "$GST_STAGING_ABS/"
               FOUND=$((FOUND + 1))
             done < <(find "$BUILD_GST_DIR" -maxdepth 2 -type f \
-                       \( -name 'lib*.so' -o -name 'lib*.dylib' \) -print0)
+                       \( -name '*.so' -o -name '*.dylib' \) -print0)
             ;;
           windows)
             while IFS= read -r -d '' plugin; do

--- a/package-gstreamer-addon/action.yml
+++ b/package-gstreamer-addon/action.yml
@@ -109,7 +109,7 @@ runs:
               echo "Copying plugin: $plugin"
               cp -f "$plugin" "$GST_STAGING_ABS/"
               FOUND=$((FOUND + 1))
-            done < <(find "$BUILD_GST_DIR" -maxdepth 1 -type f \
+            done < <(find "$BUILD_GST_DIR" -maxdepth 2 -type f \
                        \( -name 'lib*.so' -o -name 'lib*.so.*' \) -print0)
             ;;
           macos)
@@ -123,7 +123,7 @@ runs:
               echo "Copying plugin: $plugin"
               cp -f "$plugin" "$GST_STAGING_ABS/"
               FOUND=$((FOUND + 1))
-            done < <(find "$BUILD_GST_DIR" -maxdepth 1 -type f \
+            done < <(find "$BUILD_GST_DIR" -maxdepth 2 -type f \
                        \( -name 'lib*.so' -o -name 'lib*.dylib' \) -print0)
             ;;
           windows)
@@ -131,7 +131,7 @@ runs:
               echo "Copying plugin: $plugin"
               cp -f "$plugin" "$GST_STAGING_ABS/"
               FOUND=$((FOUND + 1))
-            done < <(find "$BUILD_GST_DIR" -maxdepth 1 -type f -name '*.dll' -print0)
+            done < <(find "$BUILD_GST_DIR" -maxdepth 2 -type f -name '*.dll' -print0)
             ;;
           *)
             echo "Error: unsupported os-tag '${{ inputs.os-tag }}'"

--- a/package-max-addon/action.yml
+++ b/package-max-addon/action.yml
@@ -311,7 +311,10 @@ runs:
         set -euo pipefail
         cd "$OUTPUT_DIR"
         rm -f "$ZIP_PATH"
-        if command -v zip >/dev/null 2>&1; then
+        if [[ "${RUNNER_OS:-}" == "Windows" ]] && command -v 7z >/dev/null 2>&1; then
+          # Windows zip (Git Bash) rejects -y; .mxe64 are flat files anyway
+          7z a -tzip "$ZIP_NAME" "${{ inputs.addon-name }}"
+        elif command -v zip >/dev/null 2>&1; then
           # -y preserves symlinks (matters for .mxo bundles on macOS)
           zip -ry "$ZIP_NAME" "${{ inputs.addon-name }}"
         elif command -v 7z >/dev/null 2>&1; then

--- a/package-standalone-addon/action.yml
+++ b/package-standalone-addon/action.yml
@@ -364,7 +364,10 @@ runs:
 
         cd "$STANDALONE_STAGING_ABS"
 
-        if command -v zip >/dev/null 2>&1; then
+        if [[ "${RUNNER_OS:-}" == "Windows" ]] && command -v 7z >/dev/null 2>&1; then
+          # Windows zip (Git Bash) rejects -y; .exe + dll's are flat files anyway
+          7z a -tzip "$ZIP_PATH" .
+        elif command -v zip >/dev/null 2>&1; then
           # -y preserves symlinks (important for macOS .app bundles),
           # -X drops extra file attributes for reproducibility.
           zip -r -y -X "$ZIP_PATH" .

--- a/package-standalone-addon/action.yml
+++ b/package-standalone-addon/action.yml
@@ -97,7 +97,7 @@ runs:
           echo "Copying .app bundle: $bundle"
           cp -R "$bundle" "$STANDALONE_STAGING_ABS/"
           FOUND=$((FOUND + 1))
-        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 1 -name '*.app' -type d -print0)
+        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 2 -name '*.app' -type d -print0)
 
         if [[ $FOUND -eq 0 ]]; then
           echo "Error: no .app bundles found in $BUILD_STANDALONE_DIR"
@@ -131,7 +131,7 @@ runs:
           echo "Copying .exe: $exe"
           cp -f "$exe" "$APP_DIR/"
           FOUND=$((FOUND + 1))
-        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 1 -name '*.exe' -type f -print0)
+        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 2 -name '*.exe' -type f -print0)
 
         if [[ $FOUND -eq 0 ]]; then
           echo "Error: no .exe binaries found in $BUILD_STANDALONE_DIR"
@@ -142,7 +142,7 @@ runs:
         while IFS= read -r -d '' dll; do
           echo "Copying runtime .dll: $dll"
           cp -f "$dll" "$APP_DIR/"
-        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 1 -name '*.dll' -type f -print0)
+        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 2 -name '*.dll' -type f -print0)
 
         echo "Staged contents:"
         ls -la "$APP_DIR"
@@ -177,7 +177,7 @@ runs:
           cp -f "$bin" "$APP_DIR/"
           chmod +x "$APP_DIR/$(basename "$bin")"
           FOUND=$((FOUND + 1))
-        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 1 -type f -executable -print0)
+        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 2 -type f -executable -print0)
 
         if [[ $FOUND -eq 0 ]]; then
           echo "Error: no executable binaries found in $BUILD_STANDALONE_DIR"
@@ -188,7 +188,7 @@ runs:
         while IFS= read -r -d '' so; do
           echo "Copying runtime .so: $so"
           cp -f "$so" "$APP_DIR/"
-        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 1 -type f \( -name '*.so' -o -name '*.so.*' \) -print0)
+        done < <(find "$BUILD_STANDALONE_DIR" -maxdepth 2 -type f \( -name '*.so' -o -name '*.so.*' \) -print0)
 
         echo "Staged contents:"
         ls -la "$APP_DIR"
@@ -282,7 +282,7 @@ runs:
           "$SIGNTOOL" sign //f "$PFX_FILE" //p "$PWD_ARG" \
             //tr http://timestamp.digicert.com //td sha256 //fd sha256 \
             "$bin"
-        done < <(find "$APP_DIR" -maxdepth 1 \( -name '*.exe' -o -name '*.dll' \) -print0)
+        done < <(find "$APP_DIR" -maxdepth 2 \( -name '*.exe' -o -name '*.dll' \) -print0)
 
         rm -f "$PFX_FILE"
 
@@ -311,7 +311,7 @@ runs:
         APP_DIR="$STANDALONE_STAGING_ABS/${{ inputs.addon-name }}"
 
         # Find a representative exe name for the README
-        BIN_NAME=$(find "$APP_DIR" -maxdepth 1 -name '*.exe' -printf '%f\n' | head -1)
+        BIN_NAME=$(find "$APP_DIR" -maxdepth 2 -name '*.exe' -printf '%f\n' | head -1)
         if [[ -z "$BIN_NAME" ]]; then
           BIN_NAME="${{ inputs.addon-name }}.exe"
         fi
@@ -334,7 +334,7 @@ runs:
 
         APP_DIR="$STANDALONE_STAGING_ABS/${{ inputs.addon-name }}"
 
-        BIN_NAME=$(find "$APP_DIR" -maxdepth 1 -type f -executable ! -name '*.so' ! -name '*.so.*' -printf '%f\n' | head -1)
+        BIN_NAME=$(find "$APP_DIR" -maxdepth 2 -type f -executable ! -name '*.so' ! -name '*.so.*' -printf '%f\n' | head -1)
         if [[ -z "$BIN_NAME" ]]; then
           BIN_NAME="${{ inputs.addon-name }}"
         fi

--- a/package-touchdesigner-addon/action.yml
+++ b/package-touchdesigner-addon/action.yml
@@ -236,7 +236,10 @@ runs:
         set -euo pipefail
         cd "$OUTPUT_DIR"
         rm -f "$ZIP_PATH"
-        if command -v zip >/dev/null 2>&1; then
+        if [[ "${RUNNER_OS:-}" == "Windows" ]] && command -v 7z >/dev/null 2>&1; then
+          # Windows zip (Git Bash) rejects -y; .dll plugins are flat files anyway
+          7z a -tzip "$ZIP_NAME" "${{ inputs.addon-name }}"
+        elif command -v zip >/dev/null 2>&1; then
           # -y preserves symlinks (matters for .plugin bundles on macOS)
           zip -ry "$ZIP_NAME" "${{ inputs.addon-name }}"
         elif command -v 7z >/dev/null 2>&1; then

--- a/package-vintage-addon/action.yml
+++ b/package-vintage-addon/action.yml
@@ -101,20 +101,20 @@ runs:
             echo "Copying VST2 bundle: $plugin"
             cp -R "$plugin" "$VST2_STAGING_ABS/"
             FOUND=$((FOUND + 1))
-          done < <(find "$BUILD_VST2_DIR" -maxdepth 1 -type d -name '*.vst' -print0)
+          done < <(find "$BUILD_VST2_DIR" -maxdepth 2 -type d -name '*.vst' -print0)
         elif [[ "$OS_TAG" == "windows" ]]; then
           while IFS= read -r -d '' plugin; do
             echo "Copying VST2 DLL: $plugin"
             cp -f "$plugin" "$VST2_STAGING_ABS/"
             FOUND=$((FOUND + 1))
-          done < <(find "$BUILD_VST2_DIR" -maxdepth 1 -type f -name '*.dll' -print0)
+          done < <(find "$BUILD_VST2_DIR" -maxdepth 2 -type f -name '*.dll' -print0)
         else
           # linux
           while IFS= read -r -d '' plugin; do
             echo "Copying VST2 SO: $plugin"
             cp -f "$plugin" "$VST2_STAGING_ABS/"
             FOUND=$((FOUND + 1))
-          done < <(find "$BUILD_VST2_DIR" -maxdepth 1 -type f -name '*.so' -print0)
+          done < <(find "$BUILD_VST2_DIR" -maxdepth 2 -type f -name '*.so' -print0)
         fi
 
         if [[ $FOUND -eq 0 ]]; then

--- a/package-vst3-addon/action.yml
+++ b/package-vst3-addon/action.yml
@@ -99,7 +99,7 @@ runs:
           echo "Copying VST3 bundle: $bundle"
           cp -R "$bundle" "$VST3_STAGING_ABS/"
           FOUND=$((FOUND + 1))
-        done < <(find "$BUILD_VST3_DIR" -maxdepth 1 -name '*.vst3' -type d -print0)
+        done < <(find "$BUILD_VST3_DIR" -maxdepth 2 -name '*.vst3' -type d -print0)
 
         if [[ $FOUND -eq 0 ]]; then
           # Fallback: maybe a flat file (non-standard but defensive)
@@ -107,7 +107,7 @@ runs:
             echo "Copying VST3 file: $bundle"
             cp -R "$bundle" "$VST3_STAGING_ABS/"
             FOUND=$((FOUND + 1))
-          done < <(find "$BUILD_VST3_DIR" -maxdepth 1 -name '*.vst3' -print0)
+          done < <(find "$BUILD_VST3_DIR" -maxdepth 2 -name '*.vst3' -print0)
         fi
 
         if [[ $FOUND -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Refactor `avnd-addon.yml` to fetch each per-backend SDK inline (matching the proven pattern in `avendish-template/action.yml`) instead of relying on the prebuilt ossia-sdk bundle. Lets the celtera `avendish-*-processor-template` repos call this workflow directly — their `dependencies.cmake` is intentionally thin (just FetchContent's avendish itself), so the CI now owns SDK provisioning, not the addon.

### Per-backend SDK fetches now baked into each job

| Job | SDK fetched | cmake flag |
|---|---|---|
| `pd` | `pure-data/pure-data` | `-DCMAKE_INCLUDE_PATH=$PWD/puredata/src` |
| `max` | `jcelerier/max-sdk-base` (recursive) | `-DAVND_MAXSDK_PATH=$PWD/max-sdk-base` |
| `vst3` | `steinbergmedia/vst3sdk` (recursive) + 6 `SMTG_*=OFF` lean flags | `-DVST3_SDK_ROOT=$PWD/vst3sdk` |
| `clap` | `free-audio/clap` | `-DCMAKE_PREFIX_PATH=$PWD/clap-sdk` |
| `touchdesigner` | `jcelerier/CustomOperatorSamples@add-pop-headers` | `-DTOUCHDESIGNER_SDK_PATH=$PWD/touchdesigner-sdk` |
| `python` | `setup-python@v5` + `pip install pybind11` | `-DPython_EXECUTABLE` + `-Dpybind11_DIR` |
| `wasm` | `mymindstorm/setup-emsdk@v14` | `emcmake cmake ...` |
| `vintage` / `godot` / `standalone` / `gstreamer` | (none specific) | — |
| all jobs | Boost tarball from ossia/score-sdk releases | `-DBOOST_ROOT=$PWD/boost -DBoost_NO_BOOST_CMAKE=ON -DCMAKE_POLICY_DEFAULT_CMP0167=OLD` |

### What's removed

- `uses: ossia/actions/download-ossia-sdk@master` step in every per-backend job
- `-DOSSIA_SDK=...` cmake flag
- The `# TODO: align with avendish CMake flag naming` markers — `AVND_ENABLE_<BACKEND>` is now real (celtera/avendish#104 merged the `option(AVND_ENABLE_*)` definitions)

### Preserved

- All 11 per-backend matrix structures
- Signing input forwarding (`MAC_CERT_B64`, `WIN_CERT_B64`, notarize creds)
- The three composite-merger jobs (`pd-composite`, `max-composite`, `godot-composite`)
- The `release-continuous` final job

## Test plan

- [ ] Wire one template (audio-processor) to call this reusable workflow via PR celtera/avendish-audio-processor-template#4 — first run will validate end-to-end.
- [ ] Confirm avnd-goofi-style addons (the original use case) still build green when this lands.
- [ ] Roll out to remaining 4 templates (data, ml, video, geometry) once audio confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)