### PR TITLE
avnd-addon: point composite refs at @master post-merge

### DIFF
--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -238,7 +238,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package pd backend
         id: package
-        uses: ossia/actions/package-pd-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-pd-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -375,7 +375,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package max backend
         id: package
-        uses: ossia/actions/package-max-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-max-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -565,7 +565,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package vst3 backend
         id: package
-        uses: ossia/actions/package-vst3-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-vst3-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -651,7 +651,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package clap backend
         id: package
-        uses: ossia/actions/package-clap-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-clap-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -722,7 +722,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package vintage backend
         id: package
-        uses: ossia/actions/package-vintage-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-vintage-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -800,7 +800,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package touchdesigner backend
         id: package
-        uses: ossia/actions/package-touchdesigner-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-touchdesigner-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -888,7 +888,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package python backend
         id: package
-        uses: ossia/actions/package-python-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-python-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -968,7 +968,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package godot backend
         id: package
-        uses: ossia/actions/package-godot-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-godot-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -1131,7 +1131,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package standalone backend
         id: package
-        uses: ossia/actions/package-standalone-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-standalone-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -1218,7 +1218,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package gstreamer backend
         id: package
-        uses: ossia/actions/package-gstreamer-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-gstreamer-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon
@@ -1283,7 +1283,7 @@ jobs:
           cmake --build addon/build --config Release
       - name: Package wasm backend
         id: package
-        uses: ossia/actions/package-wasm-addon@drop-ossia-sdk-dep
+        uses: ossia/actions/package-wasm-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
           addon-path: addon


### PR DESCRIPTION
## Summary

The 11 `ossia/actions/package-*-addon` composite `uses:` refs in `avnd-addon.yml` were pinned to `@drop-ossia-sdk-dep` for in-PR testing (#9). That branch is now merged, so this flips them to `@master` — otherwise the reusable workflow breaks the moment the feature branch is deleted.

Mechanical one-line-per-ref change; validated green end-to-end on celtera/avendish-audio-processor-template before #9 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)