### PR TITLE
score-addon: add `targets` allowlist to filter the build matrix

### DIFF
--- a/.github/workflows/builds-dev.yml
+++ b/.github/workflows/builds-dev.yml
@@ -2,33 +2,46 @@ name: CMake build (dev)
 
 on:
   workflow_call:
+    inputs:
+      targets:
+        description: 'Space-separated os/arch triples to build (empty = all).'
+        required: false
+        default: ''
+        type: string
 
 jobs:
+  setup:
+    name: Setup matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+      - name: Compute build matrix
+        id: filter
+        shell: bash
+        env:
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          configs='[
+            {"name":"Windows","triple":"windows/x86_64","os":"windows-latest","dependencies":"curl -L -O https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-win.zip && unzip ninja-win.zip","additional_flags":"-GNinja"},
+            {"name":"Ubuntu","triple":"linux/x86_64","os":"ubuntu-latest","dependencies":"sudo apt -y update; sudo apt install -yqq libgl-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev libxcomposite-dev libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libxcb-*-dev libX11-*-dev libz-dev libtinfo6 libxext-dev","additional_flags":""},
+            {"name":"macOS","triple":"macos/arm64","os":"macos-15","dependencies":"","additional_flags":""}
+          ]'
+          if [ -z "${TARGETS// }" ]; then
+            matrix="$configs"
+          else
+            matrix=$(jq -c --arg t "$TARGETS" '[ .[] | select( .triple as $tr | ($t | split(" ") | map(select(. != ""))) | index($tr) ) ]' <<< "$configs")
+          fi
+          echo "matrix=$(jq -c . <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: setup
     name: "Dev ${{ matrix.config.name }}"
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {
-              name: "Windows",
-              os: windows-latest,
-              dependencies: "curl -L -O https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-win.zip && unzip ninja-win.zip",
-              additional_flags: "-GNinja"
-            }
-          - {
-              name: "Ubuntu",
-              os: ubuntu-latest,
-              dependencies: "sudo apt -y update; sudo apt install -yqq libgl-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev libxcomposite-dev libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libxcb-*-dev libX11-*-dev libz-dev libtinfo6 libxext-dev",
-              additional_flags: ""
-            }
-          - {
-              name: "macOS",
-              os: macos-15,
-              dependencies: "",
-              additional_flags: ""
-            }
+        config: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Support longpaths
         run: git config --global core.longpaths true

--- a/.github/workflows/builds-sdk.yml
+++ b/.github/workflows/builds-sdk.yml
@@ -2,34 +2,47 @@ name: CMake build (SDK)
 
 on:
   workflow_call:
+    inputs:
+      targets:
+        description: 'Space-separated os/arch triples to build (empty = all).'
+        required: false
+        default: ''
+        type: string
 
 jobs:
+  setup:
+    name: Setup matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+      - name: Compute build matrix
+        id: filter
+        shell: bash
+        env:
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          configs='[
+            {"name":"Windows","triple":"windows/x86_64","os":"windows-latest","dependencies":"curl -L -O https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-win.zip && unzip ninja-win.zip","additional_flags":"-GNinja"},
+            {"name":"Ubuntu","triple":"linux/x86_64","os":"ubuntu-latest","dependencies":"sudo apt -y update; sudo apt install -yqq libgl-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libxcomposite-dev libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libxcb-*-dev libX11-*-dev libz-dev libtinfo6 libxext-dev","additional_flags":""},
+            {"name":"macOS","triple":"macos/arm64","os":"macos-15","dependencies":"","additional_flags":""}
+          ]'
+          if [ -z "${TARGETS// }" ]; then
+            matrix="$configs"
+          else
+            matrix=$(jq -c --arg t "$TARGETS" '[ .[] | select( .triple as $tr | ($t | split(" ") | map(select(. != ""))) | index($tr) ) ]' <<< "$configs")
+          fi
+          echo "matrix=$(jq -c . <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: setup
     name: "SDK ${{ matrix.config.name }} ${{ matrix.version }}"
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false
       matrix:
         version: [ "latest", "continuous" ]
-        config:
-          - {
-              name: "Windows",
-              os: windows-latest,
-              dependencies: "curl -L -O https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-win.zip && unzip ninja-win.zip",
-              additional_flags: "-GNinja"
-            }
-          - {
-              name: "Ubuntu",
-              os: ubuntu-latest,
-              dependencies: "sudo apt -y update; sudo apt install -yqq libgl-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libxcomposite-dev libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libxcb-*-dev libX11-*-dev libz-dev libtinfo6 libxext-dev",
-              additional_flags: ""
-            }
-          - {
-              name: "macOS",
-              os: macos-15,
-              dependencies: "",
-              additional_flags: ""
-            }
+        config: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Support longpaths
         run: git config --global core.longpaths true

--- a/.github/workflows/jit.yml
+++ b/.github/workflows/jit.yml
@@ -2,9 +2,40 @@ name: JIT
 
 on:
   workflow_call:
+    inputs:
+      targets:
+        description: 'Space-separated os/arch triples to build (empty = all).'
+        required: false
+        default: ''
+        type: string
 
 jobs:
+  setup:
+    name: Setup matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+      - name: Compute build matrix
+        id: filter
+        shell: bash
+        env:
+          TARGETS: ${{ inputs.targets }}
+        run: |
+          configs='[
+            {"name":"Windows","triple":"windows/x86_64","os":"windows-latest"},
+            {"name":"Ubuntu","triple":"linux/x86_64","os":"ubuntu-latest"},
+            {"name":"macOS","triple":"macos/arm64","os":"macos-15"}
+          ]'
+          if [ -z "${TARGETS// }" ]; then
+            matrix="$configs"
+          else
+            matrix=$(jq -c --arg t "$TARGETS" '[ .[] | select( .triple as $tr | ($t | split(" ") | map(select(. != ""))) | index($tr) ) ]' <<< "$configs")
+          fi
+          echo "matrix=$(jq -c . <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
   jit:
+    needs: setup
     name: "JIT ${{ matrix.config.name }} ${{ matrix.version }}"
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 10
@@ -12,10 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "latest", "continuous" ]
-        config:
-          - { name: "Windows", os: windows-latest }
-          - { name: "Ubuntu", os: ubuntu-latest }
-          - { name: "macOS", os: macos-15 }
+        config: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Support longpaths

--- a/.github/workflows/score-addon.yml
+++ b/.github/workflows/score-addon.yml
@@ -51,20 +51,34 @@ on:
         required: false
         default: true
         type: boolean
+      targets:
+        description: >-
+          Space-separated os/arch triples to build (e.g.
+          "linux/x86_64 windows/x86_64"). Empty = every platform.
+          Filters the dev / sdk / jit matrices; release is unaffected.
+        required: false
+        default: ''
+        type: string
 
 jobs:
   dev:
     if: inputs.dev
     uses: ossia/actions/.github/workflows/builds-dev.yml@master
     secrets: inherit
+    with:
+      targets: ${{ inputs.targets }}
   sdk:
     if: inputs.sdk
     uses: ossia/actions/.github/workflows/builds-sdk.yml@master
     secrets: inherit
+    with:
+      targets: ${{ inputs.targets }}
   jit:
     if: inputs.jit
     uses: ossia/actions/.github/workflows/jit.yml@master
     secrets: inherit
+    with:
+      targets: ${{ inputs.targets }}
   release:
     if: inputs.release
     uses: ossia/actions/.github/workflows/release.yml@master


### PR DESCRIPTION
## Summary
- Adds an optional `targets` input (space-separated os/arch triples) to the bundled `score-addon.yml` pipeline, threaded into `builds-dev.yml`, `builds-sdk.yml`, and `jit.yml`.
- **Empty = build every platform** (default), so all existing callers are byte-for-byte unaffected.
- When set (e.g. `targets: "linux/x86_64 windows/x86_64"`), a `setup` job filters the platform config list by triple and the build job consumes it via `fromJSON`. A dynamic matrix is required because a job-level `if:` cannot read the `matrix` context.
- `release.yml` has no OS matrix and is untouched.

## Motivation
Some addons can only build on a subset of platforms — e.g. `score-addon-librediffusion` requires CUDA, so macOS cannot build at all. Rather than disabling a whole track (`jit: false`), addons can now keep JIT/dev/sdk running on the platforms that work and drop only the impossible ones.

## Triples
`linux/x86_64`, `windows/x86_64`, `macos/arm64` — the same os-tag/arch-tag form used in `avnd-addon.yml`.

## Test plan
- [x] YAML parses for all four workflows
- [x] jq filter verified locally: empty→all 3, `linux/x86_64 windows/x86_64`→Win+Ubuntu, `macos/arm64`→macOS only
- [ ] Validate end-to-end via a caller addon (librediffusion) setting `targets: "linux/x86_64 windows/x86_64"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)