### PR TITLE
package-*: emit native Windows zip-path so upload-artifact finds it

### DIFF
--- a/package-clap-addon/action.yml
+++ b/package-clap-addon/action.yml
@@ -239,6 +239,8 @@ runs:
           exit 1
         fi
 
-        echo "zip-path=$ZIP_PATH" >> $GITHUB_OUTPUT
+        ZIP_PATH_OUT="$ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> $GITHUB_OUTPUT
         echo "Created: $ZIP_PATH"
         ls -la "$ZIP_PATH"

--- a/package-godot-addon/action.yml
+++ b/package-godot-addon/action.yml
@@ -336,4 +336,6 @@ runs:
         fi
         echo "Created zip: $GD_ZIP_PATH"
         ls -la "$GD_ZIP_PATH"
-        echo "zip-path=$GD_ZIP_PATH" >> "$GITHUB_OUTPUT"
+        ZIP_PATH_OUT="$GD_ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$GD_ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> "$GITHUB_OUTPUT"

--- a/package-gstreamer-addon/action.yml
+++ b/package-gstreamer-addon/action.yml
@@ -238,6 +238,8 @@ runs:
           exit 1
         fi
 
-        echo "zip-path=$ZIP_PATH" >> $GITHUB_OUTPUT
+        ZIP_PATH_OUT="$ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> $GITHUB_OUTPUT
         echo "Created: $ZIP_PATH"
         ls -la "$ZIP_PATH"

--- a/package-max-addon/action.yml
+++ b/package-max-addon/action.yml
@@ -323,4 +323,6 @@ runs:
           powershell -NoProfile -Command "Compress-Archive -Path '${{ inputs.addon-name }}' -DestinationPath '$ZIP_NAME' -Force"
         fi
         echo "Created zip: $ZIP_PATH"
-        echo "zip-path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
+        ZIP_PATH_OUT="$ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> "$GITHUB_OUTPUT"

--- a/package-pd-addon/action.yml
+++ b/package-pd-addon/action.yml
@@ -201,4 +201,6 @@ runs:
           fi
         fi
         echo "Created zip: $ZIP_PATH"
-        echo "zip-path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
+        ZIP_PATH_OUT="$ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> "$GITHUB_OUTPUT"

--- a/package-python-addon/action.yml
+++ b/package-python-addon/action.yml
@@ -260,4 +260,6 @@ runs:
         fi
         echo "Created zip: $PY_ZIP_PATH"
         ls -la "$PY_ZIP_PATH"
-        echo "zip-path=$PY_ZIP_PATH" >> "$GITHUB_OUTPUT"
+        ZIP_PATH_OUT="$PY_ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$PY_ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> "$GITHUB_OUTPUT"

--- a/package-standalone-addon/action.yml
+++ b/package-standalone-addon/action.yml
@@ -378,6 +378,8 @@ runs:
           exit 1
         fi
 
-        echo "zip-path=$ZIP_PATH" >> $GITHUB_OUTPUT
+        ZIP_PATH_OUT="$ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> $GITHUB_OUTPUT
         echo "Created: $ZIP_PATH"
         ls -la "$ZIP_PATH"

--- a/package-touchdesigner-addon/action.yml
+++ b/package-touchdesigner-addon/action.yml
@@ -248,4 +248,6 @@ runs:
           powershell -NoProfile -Command "Compress-Archive -Path '${{ inputs.addon-name }}' -DestinationPath '$ZIP_NAME' -Force"
         fi
         echo "Created zip: $ZIP_PATH"
-        echo "zip-path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
+        ZIP_PATH_OUT="$ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> "$GITHUB_OUTPUT"

--- a/package-vintage-addon/action.yml
+++ b/package-vintage-addon/action.yml
@@ -252,6 +252,8 @@ runs:
           exit 1
         fi
 
-        echo "zip-path=$ZIP_PATH" >> $GITHUB_OUTPUT
+        ZIP_PATH_OUT="$ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> $GITHUB_OUTPUT
         echo "Created: $ZIP_PATH"
         ls -la "$ZIP_PATH"

--- a/package-vst3-addon/action.yml
+++ b/package-vst3-addon/action.yml
@@ -251,6 +251,8 @@ runs:
           exit 1
         fi
 
-        echo "zip-path=$ZIP_PATH" >> $GITHUB_OUTPUT
+        ZIP_PATH_OUT="$ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> $GITHUB_OUTPUT
         echo "Created: $ZIP_PATH"
         ls -la "$ZIP_PATH"

--- a/package-wasm-addon/action.yml
+++ b/package-wasm-addon/action.yml
@@ -180,4 +180,6 @@ runs:
         fi
         echo "Created zip: $WASM_ZIP_PATH"
         ls -la "$WASM_ZIP_PATH"
-        echo "zip-path=$WASM_ZIP_PATH" >> "$GITHUB_OUTPUT"
+        ZIP_PATH_OUT="$WASM_ZIP_PATH"
+        command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$WASM_ZIP_PATH")"
+        echo "zip-path=$ZIP_PATH_OUT" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
On Windows runners (git-bash), the package-*-addon actions compute the zip path via `$(cd "$output-dir" && pwd)`, which returns an **MSYS path** like `/d/a/score-addon-x/score-addon-x/package/foo.zip`. That raw MSYS path was emitted as the `zip-path` step output and consumed by the reusable workflow through `actions/upload-artifact@v4` (`path: ${{ steps.package.outputs.zip-path }}`).

`upload-artifact@v4` runs in Node and cannot resolve an MSYS path. It logs:

```
##[warning]No files were found with the provided path: /d/a/...
```

and, because `if-no-files-found: warn`, uploads **nothing** while the job still reports success. Consequences:

- Downstream `*-composite` jobs (e.g. `max-composite`) fail with "no per-OS artifacts found".
- Single-artifact backends silently ship nothing on Windows.

## Fix

At the single point where `zip-path` is written to `$GITHUB_OUTPUT`, convert the path to a native Windows path with `cygpath -w` **only when `cygpath` is available** (i.e. on Windows git-bash). On Linux/macOS `cygpath` does not exist, so the path is emitted unchanged:

```bash
ZIP_PATH_OUT="$ZIP_PATH"
command -v cygpath >/dev/null 2>&1 && ZIP_PATH_OUT="$(cygpath -w "$ZIP_PATH")"
echo "zip-path=$ZIP_PATH_OUT" >> "$GITHUB_OUTPUT"
```

The conversion is applied **only to the emitted output**. The earlier `cd`/`zip`/`rm` steps deliberately keep using the original MSYS path, which they rely on.

Applied to all 11 `package-*-addon` actions: pd, max, vst3, clap, vintage, touchdesigner, python, godot, standalone, gstreamer, wasm (each had exactly one `zip-path=` emission, using its own variable name).

This unblocks `max-composite` and fixes Windows artifact uploads across all addon backends generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ieWXB1cvaTVuVGuEmyKKP