### PR TITLE
chore: self-hosted Renovate runner for the avendish plugins

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,45 @@
+name: renovate
+
+on:
+  schedule:
+    # weekdays, 04:00 UTC
+    - cron: "0 4 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "dry-run = preview only (no PRs); apply = create PRs"
+        type: choice
+        options: [dry-run, apply]
+        default: dry-run
+      logLevel:
+        description: "Renovate log level"
+        type: choice
+        options: [info, debug]
+        default: info
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: renovatebot/github-action@v46.1.17
+        with:
+          configurationFile: renovate-global.json5
+          # PAT with contents + pull-requests write on the target repos across
+          # the ossia / celtera / sat-mtl orgs. The default GITHUB_TOKEN cannot
+          # reach other repositories, so autodiscover needs this.
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ github.event.inputs.logLevel || 'info' }}
+          # scheduled runs create PRs; a manual run only creates PRs when
+          # explicitly launched with mode=apply, otherwise it is a dry run.
+          RENOVATE_DRY_RUN: >-
+            ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.mode != 'apply') && 'full' || '' }}

--- a/renovate-global.json5
+++ b/renovate-global.json5
@@ -1,0 +1,69 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  // ==================================================================
+  // Self-hosted (global) options — how the runner discovers repos.
+  // ==================================================================
+  platform: "github",
+  autodiscover: true,
+
+  // Which repositories to manage. Globs, minimatch syntax. This is the one
+  // knob to widen/narrow coverage; the token must have access to whatever
+  // matches. Scoped to the avendish plugin families by default.
+  autodiscoverFilter: [
+    "ossia/score-addon-*",
+    "celtera/*",
+    "sat-mtl/carto-tcp-avendish",
+  ],
+
+  // Run the inherited config below directly on every matched repo, without
+  // requiring each repo to merge an onboarding PR first. Flip to
+  // `onboarding: true` + `requireConfig: "required"` if you'd rather each
+  // repo opt in by merging a Renovate onboarding PR.
+  onboarding: false,
+  requireConfig: "optional",
+
+  gitAuthor: "ossia-renovate-bot <renovate@ossia.io>",
+
+  // ==================================================================
+  // Config inherited by every managed repository.
+  // ==================================================================
+  extends: [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":disableRateLimiting",
+  ],
+  labels: ["dependencies"],
+  prConcurrentLimit: 5,
+
+  // avendish (and any other vendored submodule) pinned as a git submodule:
+  // bump the recorded commit when the submodule's branch moves.
+  "git-submodules": { enabled: true, versioning: "git" },
+
+  // CMake FetchContent / ExternalProject pins. Two mutually-exclusive
+  // managers so a commit pin and a version-tag pin are handled correctly:
+  customManagers: [
+    // (1) commit pin: GIT_TAG <40-hex>  → git-refs digest, tracked on `main`.
+    //     This is how avendish is pinned in the plugin CMakeLists; the PR
+    //     advances the digest when celtera/avendish@main moves.
+    {
+      customType: "regex",
+      managerFilePatterns: ["/CMakeLists\\.txt$/", "/\\.cmake$/"],
+      matchStrings: [
+        "GIT_REPOSITORY\\s+\"?https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\"?\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{7,40})",
+      ],
+      currentValueTemplate: "main",
+      datasourceTemplate: "git-refs",
+    },
+    // (2) version-tag pin: GIT_TAG v1.2.3 / 1.2.3  → github-tags.
+    {
+      customType: "regex",
+      managerFilePatterns: ["/CMakeLists\\.txt$/", "/\\.cmake$/"],
+      matchStrings: [
+        "GIT_REPOSITORY\\s+\"?https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\"?\\s+GIT_TAG\\s+(?<currentValue>v[\\w.-]+|[0-9]+\\.[\\w.-]+)",
+      ],
+      datasourceTemplate: "github-tags",
+    },
+  ],
+}


### PR DESCRIPTION
Adds one autodiscover Renovate runner that keeps **every avendish plugin repo**
up to date — no per-repo `renovate.json5` needed.

**Files**
- `renovate-global.json5` — self-hosted global config. `autodiscover: true` with
  `autodiscoverFilter` scoped to `ossia/score-addon-*`, `celtera/*`, and
  `sat-mtl/carto-tcp-avendish`. Every matched repo inherits `config:recommended`
  + the dependency dashboard, the **git-submodules** manager (for repos that
  vendor avendish as a submodule), and two CMake `customManagers`:
  - commit pins (`GIT_TAG <40-hex>`) → `git-refs`, tracked on `main` — this is how
    avendish is pinned via `FetchContent`; the bump PR advances the digest when
    `celtera/avendish@main` moves;
  - version-tag pins (`GIT_TAG v1.2.3`) → `github-tags`.
  The two managers are mutually exclusive so a commit and a tag are never
  double-matched.
- `.github/workflows/renovate.yml` — runs it weekdays at 04:00 UTC, plus manual
  dispatch. A manual run defaults to a **dry run** (preview, opens nothing); pass
  `mode: apply` (or let the schedule fire) to open PRs.

**Setup before it does anything**
1. Add a repository/org secret **`RENOVATE_TOKEN`** — a PAT (classic `repo`, or
   fine-grained with *Contents* + *Pull requests* write) that can reach the
   plugin repos across the `ossia` / `celtera` / `sat-mtl` orgs. The default
   `GITHUB_TOKEN` can't autodiscover other repositories, so this is required.
2. Run the workflow manually with `mode: dry-run` and check the logs to confirm
   the discovered repo set and proposed PRs look right.
3. Merge, or let the schedule take over, to start opening real PRs.

Coverage widens/narrows by editing `autodiscoverFilter`. This replaces the need
to hand-author a `renovate.json5` in each of the ~30 avendish plugin repos;
`onboarding: false` + `requireConfig: "optional"` means the shared config applies
directly, so no onboarding PR has to be merged per repo first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEQpn4ioAAVNStGrGVMJTw)_