### PR TITLE
fix: give the Renovate git-refs manager a full repository URL

### DIFF
--- a/renovate-global.json5
+++ b/renovate-global.json5
@@ -46,17 +46,20 @@
   customManagers: [
     // (1) commit pin: GIT_TAG <40-hex>  → git-refs digest, tracked on `main`.
     //     This is how avendish is pinned in the plugin CMakeLists; the PR
-    //     advances the digest when celtera/avendish@main moves.
+    //     advances the digest when celtera/avendish@main moves. git-refs does
+    //     `git ls-remote <packageName>`, so packageName must be the full URL.
     {
       customType: "regex",
       managerFilePatterns: ["/CMakeLists\\.txt$/", "/\\.cmake$/"],
       matchStrings: [
         "GIT_REPOSITORY\\s+\"?https://github\\.com/(?<depName>[^\\s\"]+?)(?:\\.git)?\"?\\s+GIT_TAG\\s+(?<currentDigest>[0-9a-f]{7,40})",
       ],
+      packageNameTemplate: "https://github.com/{{{depName}}}",
       currentValueTemplate: "main",
       datasourceTemplate: "git-refs",
     },
     // (2) version-tag pin: GIT_TAG v1.2.3 / 1.2.3  → github-tags.
+    //     github-tags accepts the owner/repo short form directly.
     {
       customType: "regex",
       managerFilePatterns: ["/CMakeLists\\.txt$/", "/\\.cmake$/"],


### PR DESCRIPTION
Follow-up to #15. The first dry-run failed for every repo pinning avendish:

```
["ls-remote", "celtera/avendish"]
fatal: 'celtera/avendish' does not appear to be a git repository
```

The `git-refs` datasource runs `git ls-remote <packageName>` **literally**, so the
`owner/repo` short form isn't a valid remote. This sets `packageName` to the full
`https://github.com/{{depName}}` URL via `packageNameTemplate` (depName stays
`owner/repo` for display and branch grouping). The `github-tags` manager is
unchanged — it accepts the short form.

**Verified:** a dry-run dispatched on this branch
([run #3](https://github.com/ossia/actions/actions/runs/28675588566)) completed
**successfully** with no lookup errors, where the previous config errored out.

After merge, dispatch the workflow with `mode: apply` (or let the weekday schedule
fire) to open the real bump PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEQpn4ioAAVNStGrGVMJTw)_