### PR TITLE
chore: group Renovate updates to cut CI cost

### DIFF
--- a/renovate-global.json5
+++ b/renovate-global.json5
@@ -32,14 +32,40 @@
     "config:recommended",
     ":dependencyDashboard",
     ":semanticCommits",
-    ":disableRateLimiting",
   ],
   labels: ["dependencies"],
+
+  // Throttle so we don't flood CI: at most a handful of open PRs / new
+  // branches per repo at a time (each branch = one CI build).
   prConcurrentLimit: 5,
+  branchConcurrentLimit: 5,
+  prHourlyLimit: 2,
 
   // avendish (and any other vendored submodule) pinned as a git submodule:
   // bump the recorded commit when the submodule's branch moves.
   "git-submodules": { enabled: true, versioning: "git" },
+
+  // ------------------------------------------------------------------
+  // Grouping — the key to keeping CI cheap. Since every PR triggers a
+  // build that takes hours, we collapse updates into as few PRs as
+  // possible: one combined PR per repo for everything routine, and a
+  // separate PR for avendish (the dependency we actually track, kept
+  // isolated so an unrelated update can't block it). To collapse even
+  // further (a single PR per repo, avendish included), delete the second
+  // rule below.
+  // ------------------------------------------------------------------
+  packageRules: [
+    {
+      matchPackageNames: ["*"],
+      groupName: "all dependencies",
+      groupSlug: "all",
+    },
+    {
+      matchPackageNames: ["/celtera\\/avendish/"],
+      groupName: "avendish",
+      groupSlug: "avendish",
+    },
+  ],
 
   // CMake FetchContent / ExternalProject pins. Two mutually-exclusive
   // managers so a commit pin and a version-tag pin are handled correctly:

--- a/renovate-global.json5
+++ b/renovate-global.json5
@@ -48,12 +48,18 @@
   // ------------------------------------------------------------------
   // Grouping — the key to keeping CI cheap. Since every PR triggers a
   // build that takes hours, we collapse updates into as few PRs as
-  // possible: one combined PR per repo for everything routine, and a
-  // separate PR for avendish (the dependency we actually track, kept
-  // isolated so an unrelated update can't block it). To collapse even
-  // further (a single PR per repo, avendish included), delete the second
-  // rule below.
+  // possible:
+  //   - `separateMajorMinor: false` puts major updates in the same PR as
+  //     minor/patch (rather than a separate renovate/major-* PR), because
+  //     build cost outweighs isolating majors here;
+  //   - the packageRules below then bundle everything in a repo into one
+  //     "all" PR, keeping only avendish separate (the dependency we track,
+  //     so an unrelated bump can't block it).
+  // Net: ~one combined PR per repo, plus the avendish PR where present.
+  // To also fold avendish in (a single PR per repo), delete the second
+  // rule. To go back to isolating majors, remove `separateMajorMinor`.
   // ------------------------------------------------------------------
+  separateMajorMinor: false,
   packageRules: [
     {
       matchPackageNames: ["*"],


### PR DESCRIPTION
Since every PR triggers a build that takes hours, this collapses updates into as
few PRs as possible.

**What changes**
- `separateMajorMinor: false` — majors ride in the same PR as minor/patch instead
  of separate `renovate/major-*` PRs (build cost outweighs isolating majors here).
- `packageRules`: one combined `renovate/all` PR per repo, with **avendish kept on
  its own PR** (`renovate/avendish`) so an unrelated bump can't stall the
  dependency we track.
- Drop `:disableRateLimiting`; add throttles (`prConcurrentLimit: 5`,
  `branchConcurrentLimit: 5`, `prHourlyLimit: 2`) so branches/builds trickle out.

**Verified** by dry-runs on this branch — proposed PR count drops **101 → 56**:

| branch | count |
|---|---|
| `renovate/all` (combined per-repo, majors included) | 32 |
| `renovate/avendish` (isolated) | 11 |
| `renovate/github-artifact-actions` | 13 |

Per-repo: **21 repos get 1 PR, 16 get 2, 1 gets 3.** Down from ~101 individual
PRs.

**About `github-artifact-actions`:** `config:recommended` deliberately groups the
`actions/upload-artifact` + `download-artifact` **v3→v4** migration into its own
PR (they must bump together; it's a breaking change), so it stays separate on
purpose. It can be folded into `renovate/all` with an explicit override rule, at
the risk of a broken migration stalling the whole combined PR — left separate by
default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)