### PR TITLE
avnd-addon: consume (and sign) CMake-assembled addon packages for all backends

### DIFF
--- a/.github/workflows/avnd-addon.yml
+++ b/.github/workflows/avnd-addon.yml
@@ -357,8 +357,21 @@ jobs:
             ${AVND_OFF} \
             -DAVND_ENABLE_PD=ON
           cmake --build addon/build --config Release
+      # Pd externals are not code-signed, so the CMake package (which also carries
+      # the generated <name>-help.pd patches) is just zipped. Falls through to the
+      # bash packager when the addon produced no addon/build/package/<name>/.
+      - name: Prefer CMake-built package (pd)
+        id: cmakepkg
+        uses: ossia/actions/package-cmake-addon@master
+        with:
+          addon-name: ${{ github.event.repository.name }}
+          build-dir: addon/build
+          backend: pd
+          os-tag: ${{ matrix.os-tag }}
+          arch-tag: ${{ matrix.arch-tag }}
       - name: Package pd backend
         id: package
+        if: steps.cmakepkg.outputs.zip-path == ''
         uses: ossia/actions/package-pd-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
@@ -377,7 +390,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: pd-${{ matrix.os-tag }}-${{ matrix.arch-tag }}
-          path: ${{ steps.package.outputs.zip-path }}
+          path: ${{ steps.cmakepkg.outputs.zip-path || steps.package.outputs.zip-path }}
 
   # ---------------- pd-composite ----------------
   # Pure Data via Deken expects a single cross-platform folder containing
@@ -494,24 +507,26 @@ jobs:
             ${AVND_OFF} \
             -DAVND_ENABLE_MAX=ON
           cmake --build addon/build --config Release
-      # If the addon's CMake assembled its own package (avnd_addon_package, e.g.
-      # to bundle a runtime dependency the bash packager can't know about), zip it
-      # and skip the bash packager. Backwards-compatible: addons that don't produce
-      # addon/build/package/<name>/ fall through to the package-max-addon action.
+      # If the addon's CMake assembled its own package (the default via
+      # avnd_addon_finalize, or an explicit avnd_addon_package call), sign + zip
+      # that and skip the bash packager. Backwards-compatible: addons that don't
+      # produce addon/build/package/<name>/ fall through to package-max-addon.
       - name: Prefer CMake-built package (max)
         id: cmakepkg
-        shell: bash
-        run: |
-          NAME="${{ github.event.repository.name }}"
-          if [ -d "addon/build/package/$NAME" ]; then
-            mkdir -p package
-            OUT="package/$NAME-max-${{ matrix.os-tag }}-${{ matrix.arch-tag }}.zip"
-            ( cd addon/build/package && cmake -E tar cf "$GITHUB_WORKSPACE/$OUT" --format=zip "$NAME" )
-            echo "zip-path=$OUT" >> "$GITHUB_OUTPUT"
-            echo "Using CMake-built package: $OUT"
-          else
-            echo "No CMake package dir; using the bash packager."
-          fi
+        uses: ossia/actions/package-cmake-addon@master
+        with:
+          addon-name: ${{ github.event.repository.name }}
+          build-dir: addon/build
+          backend: max
+          os-tag: ${{ matrix.os-tag }}
+          arch-tag: ${{ matrix.arch-tag }}
+          macos-certificate-base64: ${{ secrets.MAC_CERT_B64 }}
+          macos-certificate-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          macos-notarize-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          macos-notarize-apple-id: ${{ secrets.APPLE_ID }}
+          macos-notarize-password: ${{ secrets.APPLE_ALTOOL_PASSWORD }}
+          windows-certificate-base64: ${{ secrets.WIN_CERT_B64 }}
+          windows-certificate-password: ${{ secrets.WIN_CERT_PASSWORD }}
       - name: Package max backend
         id: package
         if: steps.cmakepkg.outputs.zip-path == ''
@@ -936,24 +951,26 @@ jobs:
             ${AVND_OFF} \
             -DAVND_ENABLE_TOUCHDESIGNER=ON
           cmake --build addon/build --config Release
-      # If the addon's CMake assembled its own package (avnd_addon_package, e.g.
-      # to bundle a runtime dependency the bash packager can't know about), zip it
-      # and skip the bash packager. Backwards-compatible: addons that don't produce
-      # addon/build/package/<name>/ fall through to the package-touchdesigner-addon action.
+      # If the addon's CMake assembled its own package (the default via
+      # avnd_addon_finalize, or an explicit avnd_addon_package call), sign + zip
+      # that and skip the bash packager. Backwards-compatible: addons that don't
+      # produce addon/build/package/<name>/ fall through to package-touchdesigner-addon.
       - name: Prefer CMake-built package (touchdesigner)
         id: cmakepkg
-        shell: bash
-        run: |
-          NAME="${{ github.event.repository.name }}"
-          if [ -d "addon/build/package/$NAME" ]; then
-            mkdir -p package
-            OUT="package/$NAME-touchdesigner-${{ matrix.os-tag }}-${{ matrix.arch-tag }}.zip"
-            ( cd addon/build/package && cmake -E tar cf "$GITHUB_WORKSPACE/$OUT" --format=zip "$NAME" )
-            echo "zip-path=$OUT" >> "$GITHUB_OUTPUT"
-            echo "Using CMake-built package: $OUT"
-          else
-            echo "No CMake package dir; using the bash packager."
-          fi
+        uses: ossia/actions/package-cmake-addon@master
+        with:
+          addon-name: ${{ github.event.repository.name }}
+          build-dir: addon/build
+          backend: touchdesigner
+          os-tag: ${{ matrix.os-tag }}
+          arch-tag: ${{ matrix.arch-tag }}
+          macos-certificate-base64: ${{ secrets.MAC_CERT_B64 }}
+          macos-certificate-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          macos-notarize-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          macos-notarize-apple-id: ${{ secrets.APPLE_ID }}
+          macos-notarize-password: ${{ secrets.APPLE_ALTOOL_PASSWORD }}
+          windows-certificate-base64: ${{ secrets.WIN_CERT_B64 }}
+          windows-certificate-password: ${{ secrets.WIN_CERT_PASSWORD }}
       - name: Package touchdesigner backend
         id: package
         if: steps.cmakepkg.outputs.zip-path == ''
@@ -1042,8 +1059,29 @@ jobs:
             ${AVND_OFF} \
             -DAVND_ENABLE_PYTHON=ON
           cmake --build addon/build --config Release
+      # If the addon's CMake assembled its own package (the default via
+      # avnd_addon_finalize), sign + zip it (it also carries the generated
+      # <c_name>_example.py under examples/). Falls through to package-python-addon
+      # when addon/build/package/<name>/ is absent.
+      - name: Prefer CMake-built package (python)
+        id: cmakepkg
+        uses: ossia/actions/package-cmake-addon@master
+        with:
+          addon-name: ${{ github.event.repository.name }}
+          build-dir: addon/build
+          backend: python
+          os-tag: ${{ matrix.os-tag }}
+          arch-tag: ${{ matrix.arch-tag }}
+          macos-certificate-base64: ${{ secrets.MAC_CERT_B64 }}
+          macos-certificate-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          macos-notarize-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          macos-notarize-apple-id: ${{ secrets.APPLE_ID }}
+          macos-notarize-password: ${{ secrets.APPLE_ALTOOL_PASSWORD }}
+          windows-certificate-base64: ${{ secrets.WIN_CERT_B64 }}
+          windows-certificate-password: ${{ secrets.WIN_CERT_PASSWORD }}
       - name: Package python backend
         id: package
+        if: steps.cmakepkg.outputs.zip-path == ''
         uses: ossia/actions/package-python-addon@master
         with:
           addon-name: ${{ github.event.repository.name }}
@@ -1062,7 +1100,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: python-${{ matrix.os-tag }}-${{ matrix.arch-tag }}
-          path: ${{ steps.package.outputs.zip-path }}
+          path: ${{ steps.cmakepkg.outputs.zip-path || steps.package.outputs.zip-path }}
 
   # ---------------- godot ----------------
   godot:
@@ -1121,24 +1159,26 @@ jobs:
             ${AVND_OFF} \
             -DAVND_ENABLE_GODOT=ON
           cmake --build addon/build --config Release
-      # If the addon's CMake assembled its own package (avnd_addon_package, e.g.
-      # to bundle a runtime dependency the bash packager can't know about), zip it
-      # and skip the bash packager. Backwards-compatible: addons that don't produce
-      # addon/build/package/<name>/ fall through to the package-godot-addon action.
+      # If the addon's CMake assembled its own package (the default via
+      # avnd_addon_finalize, or an explicit avnd_addon_package call), sign + zip
+      # that and skip the bash packager. Backwards-compatible: addons that don't
+      # produce addon/build/package/<name>/ fall through to package-godot-addon.
       - name: Prefer CMake-built package (godot)
         id: cmakepkg
-        shell: bash
-        run: |
-          NAME="${{ github.event.repository.name }}"
-          if [ -d "addon/build/package/$NAME" ]; then
-            mkdir -p package
-            OUT="package/$NAME-godot-${{ matrix.os-tag }}-${{ matrix.arch-tag }}.zip"
-            ( cd addon/build/package && cmake -E tar cf "$GITHUB_WORKSPACE/$OUT" --format=zip "$NAME" )
-            echo "zip-path=$OUT" >> "$GITHUB_OUTPUT"
-            echo "Using CMake-built package: $OUT"
-          else
-            echo "No CMake package dir; using the bash packager."
-          fi
+        uses: ossia/actions/package-cmake-addon@master
+        with:
+          addon-name: ${{ github.event.repository.name }}
+          build-dir: addon/build
+          backend: godot
+          os-tag: ${{ matrix.os-tag }}
+          arch-tag: ${{ matrix.arch-tag }}
+          macos-certificate-base64: ${{ secrets.MAC_CERT_B64 }}
+          macos-certificate-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          macos-notarize-team-id: ${{ secrets.APPLE_TEAM_ID }}
+          macos-notarize-apple-id: ${{ secrets.APPLE_ID }}
+          macos-notarize-password: ${{ secrets.APPLE_ALTOOL_PASSWORD }}
+          windows-certificate-base64: ${{ secrets.WIN_CERT_B64 }}
+          windows-certificate-password: ${{ secrets.WIN_CERT_PASSWORD }}
       - name: Package godot backend
         id: package
         if: steps.cmakepkg.outputs.zip-path == ''

--- a/package-cmake-addon/action.yml
+++ b/package-cmake-addon/action.yml
@@ -1,0 +1,191 @@
+name: 'Package CMake-assembled avendish Addon'
+description: >-
+  Consume a package directory assembled by the addon's own CMake
+  (avnd_addon_package / the default in avnd_addon_finalize, i.e.
+  <build-dir>/package/<addon-name>/): code-sign + notarize its binaries the same
+  way the per-backend bash packagers do, then zip it. When no such directory
+  exists this is a no-op (empty zip-path output) and the caller falls back to the
+  bash packager. Signing is skipped for Pd (its externals are not signed) and
+  whenever the relevant certificate secret is absent (forks / PRs).
+
+inputs:
+  addon-name:
+    description: 'Addon name; the CMake package dir is <build-dir>/package/<addon-name>'
+    required: true
+  build-dir:
+    description: 'CMake build directory'
+    required: false
+    default: 'addon/build'
+  backend:
+    description: 'Backend being packaged: max | pd | python | touchdesigner | godot'
+    required: true
+  os-tag:
+    description: 'OS tag used in the zip name: linux | macos | windows'
+    required: true
+  arch-tag:
+    description: 'Arch tag used in the zip name: x86_64 | arm64'
+    required: true
+  macos-certificate-base64:
+    required: false
+    default: ''
+  macos-certificate-password:
+    required: false
+    default: ''
+  macos-notarize-team-id:
+    required: false
+    default: ''
+  macos-notarize-apple-id:
+    required: false
+    default: ''
+  macos-notarize-password:
+    required: false
+    default: ''
+  windows-certificate-base64:
+    required: false
+    default: ''
+  windows-certificate-password:
+    required: false
+    default: ''
+
+outputs:
+  zip-path:
+    description: 'Path to the assembled zip, or empty if no CMake package dir was present.'
+    value: ${{ steps.zip.outputs.zip-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect CMake-built package
+      id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+        NAME="${{ inputs.addon-name }}"
+        DIR="${{ inputs.build-dir }}/package/$NAME"
+        if [ -d "$DIR" ]; then
+          echo "has-dir=true" >> "$GITHUB_OUTPUT"
+          echo "pkg-dir=$DIR" >> "$GITHUB_OUTPUT"
+          echo "Found CMake-built package: $DIR"
+        else
+          echo "has-dir=false" >> "$GITHUB_OUTPUT"
+          echo "No CMake package dir ($DIR); the caller will use the bash packager."
+        fi
+
+    # --- macOS signing & notarization ---
+    # Replicates the inline pattern in package-{max,touchdesigner,godot,python}-addon,
+    # applied to every signable binary under the CMake package dir. Skipped for Pd.
+    - name: Import macOS code signing certificate
+      if: >-
+        runner.os == 'macOS' && steps.detect.outputs.has-dir == 'true'
+        && inputs.backend != 'pd' && inputs.macos-certificate-base64 != ''
+      uses: jcelerier/import-codesign-certs@master
+      with:
+        p12-file-base64: ${{ inputs.macos-certificate-base64 }}
+        p12-password: ${{ inputs.macos-certificate-password }}
+
+    - name: Sign macOS binaries
+      if: >-
+        runner.os == 'macOS' && steps.detect.outputs.has-dir == 'true'
+        && inputs.backend != 'pd' && inputs.macos-certificate-base64 != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        IDENTITY="ossia.io"
+        DIR="${{ steps.detect.outputs.pkg-dir }}"
+
+        # Bundles (.mxo external, .framework) — sign recursively.
+        while IFS= read -r -d '' b; do
+          echo "Signing bundle $b"
+          codesign --deep --force --options runtime --timestamp --sign "$IDENTITY" "$b"
+          codesign --verify --verbose=2 "$b" || true
+        done < <(find "$DIR" \( -name '*.mxo' -o -name '*.framework' \) -print0)
+
+        # Loose Mach-O (.dylib, py*.so and other .so plugins).
+        while IFS= read -r -d '' f; do
+          echo "Signing $f"
+          codesign --force --options runtime --timestamp --sign "$IDENTITY" "$f"
+          codesign --verify --verbose=2 "$f" || true
+        done < <(find "$DIR" -type f \( -name '*.dylib' -o -name '*.so' \) -print0)
+
+    - name: Notarize macOS bundles (best-effort)
+      if: >-
+        runner.os == 'macOS' && steps.detect.outputs.has-dir == 'true'
+        && inputs.backend != 'pd' && inputs.macos-certificate-base64 != ''
+        && inputs.macos-notarize-team-id != '' && inputs.macos-notarize-apple-id != ''
+        && inputs.macos-notarize-password != ''
+      shell: bash
+      run: |
+        # Non-fatal: signed-but-not-notarized artifacts still load.
+        set +e
+        DIR="${{ steps.detect.outputs.pkg-dir }}"
+        TEAM_ID="${{ inputs.macos-notarize-team-id }}"
+        APPLE_ID="${{ inputs.macos-notarize-apple-id }}"
+        APP_PWD="${{ inputs.macos-notarize-password }}"
+
+        # Stapleable bundles: notarize and staple each.
+        find "$DIR" \( -name '*.mxo' -o -name '*.framework' \) -print0 |
+        while IFS= read -r -d '' b; do
+          Z="${b}.notarize.zip"
+          /usr/bin/ditto -c -k --sequesterRsrc --keepParent "$b" "$Z"
+          echo "Notarizing bundle $b"
+          xcrun notarytool submit "$Z" --team-id "$TEAM_ID" --apple-id "$APPLE_ID" \
+            --password "$APP_PWD" --wait \
+            && xcrun stapler staple "$b" \
+            || echo "warning: notarization/stapling failed for $b; continuing"
+          rm -f "$Z"
+        done
+
+        # Loose .so/.dylib cannot be stapled; submit one zip to validate signatures.
+        if find "$DIR" -type f \( -name '*.dylib' -o -name '*.so' \) | grep -q .; then
+          TMPZIP="$(mktemp -u).zip"
+          ( cd "$DIR" && /usr/bin/ditto -c -k --keepParent . "$TMPZIP" )
+          echo "Notarizing loose Mach-O (best-effort)"
+          xcrun notarytool submit "$TMPZIP" --team-id "$TEAM_ID" --apple-id "$APPLE_ID" \
+            --password "$APP_PWD" --wait \
+            || echo "warning: notarization submission failed; continuing with signed-only artifacts"
+          rm -f "$TMPZIP"
+        fi
+
+    # --- Windows signing ---
+    - name: Sign Windows binaries
+      if: >-
+        runner.os == 'Windows' && steps.detect.outputs.has-dir == 'true'
+        && inputs.backend != 'pd' && inputs.windows-certificate-base64 != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        DIR="${{ steps.detect.outputs.pkg-dir }}"
+        PFX="$(mktemp -u).pfx"
+        echo "${{ inputs.windows-certificate-base64 }}" | base64 -d > "$PFX"
+
+        SIGNTOOL=""
+        if command -v signtool >/dev/null 2>&1; then
+          SIGNTOOL="signtool"
+        else
+          SIGNTOOL=$(find "/c/Program Files (x86)/Windows Kits/10/bin" -name signtool.exe 2>/dev/null | grep '/x64/' | sort -r | head -n1 || true)
+          [[ -z "$SIGNTOOL" ]] && SIGNTOOL=$(find "/c/Program Files (x86)/Windows Kits/10/bin" -name signtool.exe 2>/dev/null | sort -r | head -n1 || true)
+        fi
+        if [[ -z "$SIGNTOOL" ]]; then
+          echo "Error: signtool.exe not found"; exit 1
+        fi
+        echo "Using signtool: $SIGNTOOL"
+
+        while IFS= read -r -d '' f; do
+          echo "Signing $f"
+          "$SIGNTOOL" sign /f "$PFX" /p "${{ inputs.windows-certificate-password }}" \
+            /tr http://timestamp.digicert.com /td sha256 /fd sha256 "$f"
+        done < <(find "$DIR" -type f \( -name '*.mxe64' -o -name '*.dll' -o -name '*.pyd' \) -print0)
+        rm -f "$PFX"
+
+    - name: Zip CMake-built package
+      if: steps.detect.outputs.has-dir == 'true'
+      id: zip
+      shell: bash
+      run: |
+        set -euo pipefail
+        NAME="${{ inputs.addon-name }}"
+        mkdir -p package
+        OUT="package/$NAME-${{ inputs.backend }}-${{ inputs.os-tag }}-${{ inputs.arch-tag }}.zip"
+        ( cd "${{ inputs.build-dir }}/package" && cmake -E tar cf "$GITHUB_WORKSPACE/$OUT" --format=zip "$NAME" )
+        echo "zip-path=$OUT" >> "$GITHUB_OUTPUT"
+        echo "Assembled $OUT"


### PR DESCRIPTION
Companion to celtera/avendish#164, which makes CMake-native addon packaging the default (assembling `build/package/<name>/` with externals + **generated help/example patches** + metadata). This teaches the reusable addon workflow to consume those packages — and, importantly, to **sign** them.

## What

- **New composite action `package-cmake-addon`**: given `<build-dir>/package/<addon-name>/`, it code-signs + notarizes the binaries by type — `.mxo`/`.framework`/`.dylib`/`.so` on macOS (notarize + staple bundles, best-effort submit for loose Mach-O), `.mxe64`/`.dll`/`.pyd` via signtool on Windows — using the same identity (`ossia.io`) and commands the per-backend bash packagers already use, then zips it. No-op (empty `zip-path`) when the dir is absent. Signing is skipped for Pd (its externals are never signed) and whenever a certificate secret is absent (forks/PRs).
- **`avnd-addon.yml`**: every backend job (max, pd, python, touchdesigner, godot) now prefers the CMake package via that action, falling back to the existing bash packager otherwise.

## Why it also fixes a latent bug

The max/td/godot jobs already had an inline "Prefer CMake-built package" step, but it only **zipped** — so once an addon produced a CMake package, macOS/Windows binaries would ship **unsigned/un-notarized**. Routing through `package-cmake-addon` closes that. pd and python get the CMake path for the first time (their generated `-help.pd` / `_example.py` were previously dropped by the bash packagers, which only look for a hand-authored `help/` dir).

## Safety / rollout

- Fully backwards-compatible: with today's addons (no CMake package dir) every job falls through to the bash packager unchanged.
- Takes effect once an addon ships an avendish that includes celtera/avendish#164.
- Verified: `actionlint` clean; YAML parses; Linux/pd path exercised end-to-end against unmodified score-addon-puara (26 externals + 26 `-help.pd`). The macOS/Windows **signing** steps replicate the existing production commands verbatim but have not been run by me — worth watching the first signed release (a puara `continuous` run) to confirm notarization still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
