### PR TITLE
fix(package-cmake-addon): find package dir by addon NAME so help patches ship

### DIFF
--- a/package-cmake-addon/action.yml
+++ b/package-cmake-addon/action.yml
@@ -61,14 +61,32 @@ runs:
       run: |
         set -euo pipefail
         NAME="${{ inputs.addon-name }}"
-        DIR="${{ inputs.build-dir }}/package/$NAME"
+        BASE="${{ inputs.build-dir }}/package"
+        DIR="$BASE/$NAME"
+        # avnd_addon_finalize names the package dir after the addon's CMake NAME
+        # (avnd_addon_init NAME / avnd_addon_package NAME), which need not equal the
+        # repo name -- e.g. a repo "avendish-audio-processor-template" whose addon is
+        # NAME MyAudioAddon produces package/MyAudioAddon/. Prefer an exact repo-name
+        # match; otherwise, if exactly one package dir exists, use it. Without this the
+        # exact-match miss silently drops us to the bash packager, which ships the
+        # externals but not the generated help/example patches the CMake package carries.
+        if [ ! -d "$DIR" ] && [ -d "$BASE" ]; then
+          mapfile -t _dirs < <(find "$BASE" -mindepth 1 -maxdepth 1 -type d | sort)
+          if [ "${#_dirs[@]}" -eq 1 ]; then
+            DIR="${_dirs[0]}"
+            echo "No package/$NAME; using the single CMake package dir $DIR"
+          elif [ "${#_dirs[@]}" -gt 1 ]; then
+            echo "Multiple package dirs under $BASE and none named $NAME:"
+            printf '  %s\n' "${_dirs[@]}"
+          fi
+        fi
         if [ -d "$DIR" ]; then
           echo "has-dir=true" >> "$GITHUB_OUTPUT"
           echo "pkg-dir=$DIR" >> "$GITHUB_OUTPUT"
           echo "Found CMake-built package: $DIR"
         else
           echo "has-dir=false" >> "$GITHUB_OUTPUT"
-          echo "No CMake package dir ($DIR); the caller will use the bash packager."
+          echo "No CMake package dir under $BASE; the caller will use the bash packager."
         fi
 
     # --- macOS signing & notarization ---
@@ -184,8 +202,15 @@ runs:
       run: |
         set -euo pipefail
         NAME="${{ inputs.addon-name }}"
+        SRC="${{ steps.detect.outputs.pkg-dir }}"
         mkdir -p package
         OUT="package/$NAME-${{ inputs.backend }}-${{ inputs.os-tag }}-${{ inputs.arch-tag }}.zip"
-        ( cd "${{ inputs.build-dir }}/package" && cmake -E tar cf "$GITHUB_WORKSPACE/$OUT" --format=zip "$NAME" )
+        # Normalize the archive's top-level dir to the repo name regardless of what the
+        # CMake package dir is called, so the composite-merge jobs (which look for
+        # <repo>/ inside each per-OS zip) and the fallback bash packagers stay consistent.
+        rm -rf staging && mkdir -p "staging/$NAME"
+        cp -R "$SRC/." "staging/$NAME/"
+        ( cd staging && cmake -E tar cf "$GITHUB_WORKSPACE/$OUT" --format=zip "$NAME" )
+        rm -rf staging
         echo "zip-path=$OUT" >> "$GITHUB_OUTPUT"
         echo "Assembled $OUT"


### PR DESCRIPTION
## Problem

`package-cmake-addon` only looked for `build/package/<repo-name>/`, but
`avnd_addon_finalize` names the package dir after the **addon's CMake NAME**
(`avnd_addon_init NAME` / `avnd_addon_package NAME`), which is normally *not* the
repo name — e.g. repo `avendish-audio-processor-template` with addon
`NAME MyAudioAddon` produces `package/MyAudioAddon/`.

So the exact-name check always missed, `has-dir=false`, and every caller fell
back to the bash per-backend packager. **That fallback ships the externals but
not the generated Max/Pd help & example patches** the CMake package carries — so
in practice no addon's `max`/`pd`/`python` zips contained the help patches (the
tell-tale `-meta.pd` in shipped Pd zips is the fallback's fingerprint).

## Fix

- **detect**: prefer `package/<repo-name>`; else, if exactly one dir exists under
  `package/`, use it (logs an ambiguous-multiple case).
- **zip**: stage the resolved dir under the repo name before archiving, so the
  composite-merge jobs (which expect `<repo>/` inside each per-OS zip) and the
  fallback packagers stay consistent regardless of the addon's CMake `NAME`.

## Validation

Simulated against a real `avnd_addon_finalize` package tree
(`package/MyAudioAddon/`): the emitted zip is now repo-named and contains
`my_processor-help.pd` (previously dropped by the fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z4KK2Rays9dTj8J2AJcFZ
