### PR TITLE
fix(package-cmake-addon): avoid mapfile (macOS bash 3.2)

### DIFF
--- a/package-cmake-addon/action.yml
+++ b/package-cmake-addon/action.yml
@@ -71,13 +71,19 @@ runs:
         # exact-match miss silently drops us to the bash packager, which ships the
         # externals but not the generated help/example patches the CMake package carries.
         if [ ! -d "$DIR" ] && [ -d "$BASE" ]; then
-          mapfile -t _dirs < <(find "$BASE" -mindepth 1 -maxdepth 1 -type d | sort)
-          if [ "${#_dirs[@]}" -eq 1 ]; then
-            DIR="${_dirs[0]}"
+          # Portable single-dir detection. macOS runners default to bash 3.2, which
+          # has no `mapfile`, so iterate a glob instead (the -d guard skips the
+          # literal pattern when nothing matches; no nullglob needed).
+          _only=""; _n=0
+          for _d in "$BASE"/*/; do
+            [ -d "$_d" ] || continue
+            _only="${_d%/}"; _n=$((_n + 1))
+          done
+          if [ "$_n" -eq 1 ]; then
+            DIR="$_only"
             echo "No package/$NAME; using the single CMake package dir $DIR"
-          elif [ "${#_dirs[@]}" -gt 1 ]; then
-            echo "Multiple package dirs under $BASE and none named $NAME:"
-            printf '  %s\n' "${_dirs[@]}"
+          elif [ "$_n" -gt 1 ]; then
+            echo "Multiple package dirs under $BASE and none named $NAME; leaving to the bash packager."
           fi
         fi
         if [ -d "$DIR" ]; then


### PR DESCRIPTION
## Problem

The single-package-dir detection I added in #19 used `mapfile -t`, which is a
**bash 4+** builtin. GitHub's macOS runners default to **bash 3.2**, so the
`shell: bash` step failed there with `mapfile: command not found` under `set -e`
— regressing the `pd`/`max` **macOS** package jobs (Linux/Windows were fine: the
Git-Bash / Ubuntu shells are bash 4+).

## Fix

Replace `mapfile` with a portable glob loop (bash 3.2+). The `-d` guard skips the
literal glob when no package dir exists, so no `nullglob` is needed.

## Validation

- Confirmed the #19 logic itself is correct: the Linux `pd` artifact from the
  puara rebuild now carries all **26 `-help.pd`** patches (was 0).
- Tested the new loop for the single / none / multiple cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z4KK2Rays9dTj8J2AJcFZ
