### PR TITLE
package-custom-app: support the wasm target

### DIFF
--- a/package-custom-app/action.yml
+++ b/package-custom-app/action.yml
@@ -121,6 +121,7 @@ runs:
           tools/create-app-linux.sh
           tools/create-app-macos.sh
           tools/create-app-windows.sh
+          tools/create-app-wasm.sh
           tools/launcher/launcher.cpp
         sparse-checkout-cone-mode: false
 


### PR DESCRIPTION
score's `tools/create-app.sh` now supports `--platform wasm` via a new `tools/create-app-wasm.sh` (ossia/score#2130), producing a static web bundle for custom apps.

This adds `tools/create-app-wasm.sh` to the `package-custom-app` sparse-checkout so the action can find it; otherwise a `platforms: wasm` build fails with a missing script. No other change is needed — the action already forwards `--platform` to `create-app.sh`, and it installs Qt (providing `rcc`) when a `qrc-file` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)