### PR TITLE
ci: fix SDK path handling, missing runtime libs and silent 404s

### DIFF
--- a/.github/workflows/builds-sdk.yml
+++ b/.github/workflows/builds-sdk.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           configs='[
             {"name":"Windows","triple":"windows/x86_64","os":"windows-latest","dependencies":"curl -L -O https://github.com/ninja-build/ninja/releases/download/v1.13.1/ninja-win.zip && unzip ninja-win.zip","additional_flags":"-GNinja"},
-            {"name":"Ubuntu","triple":"linux/x86_64","os":"ubuntu-latest","dependencies":"sudo apt -y update; sudo apt install -yqq libgl-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libxcomposite-dev libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libxcb-*-dev libX11-*-dev libz-dev libtinfo6 libxext-dev","additional_flags":""},
+            {"name":"Ubuntu","triple":"linux/x86_64","os":"ubuntu-latest","dependencies":"sudo apt -y update; sudo apt install -yqq libgl-dev libgl1-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev libxcomposite-dev libxkbcommon-dev libxkbcommon-x11-dev libwayland-dev libxcb-*-dev libX11-*-dev libz-dev libtinfo6 libxext-dev","additional_flags":""},
             {"name":"macOS","triple":"macos/arm64","os":"macos-15","dependencies":"","additional_flags":""}
           ]'
           if [ -z "${TARGETS// }" ]; then

--- a/build-addon/action.yml
+++ b/build-addon/action.yml
@@ -54,9 +54,14 @@ runs:
       shell: bash
       run: |
         export PATH=$PATH:$PWD
+        # Callers pass either a relative path (score) or an absolute one. On
+        # Windows an absolute path arrives with backslashes, which bash would
+        # eat, so normalize the separators before resolving.
+        SCORE_IN="${{ inputs.score-path }}"
+        SCORE_SRC="$(cd "${SCORE_IN//\\//}" && pwd)"
         cmake -S ${{ inputs.addon-path }} -B ${{ env.BUILD_DIR }} \
-          -DCMAKE_MODULE_PATH=$PWD/${{ inputs.score-path }}/cmake \
-          -DSCORE_SOURCE_DIR=$PWD/${{ inputs.score-path }} \
+          -DCMAKE_MODULE_PATH="$SCORE_SRC/cmake" \
+          -DSCORE_SOURCE_DIR="$SCORE_SRC" \
           -DOSSIA_SDK=${{ inputs.ossia-sdk-path }} \
           -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} \
           -DCMAKE_UNITY_BUILD=1 \
@@ -69,19 +74,15 @@ runs:
       shell: bash
       run: |
         export PATH=$PATH:$PWD
-        echo " ! ! ! ! => " 
-        echo ${{ inputs.score-sdk-path }}/lib/cmake/score
-        echo "1:"
-        find . -name ScoreExternalAddon.cmake
-        echo "2:"
-        find . -name ScoreFunctions.cmake
-        echo "3:"
-        find ${{ inputs.score-sdk-path }} -name ScoreExternalAddon.cmake
-        echo "4:"
-        find ${{ inputs.score-sdk-path }} -name ScoreFunctions.cmake
+        # Callers pass either a relative path (./sdk/usr) or an absolute one
+        # under the runner temp dir. On Windows an absolute path arrives with
+        # backslashes, which bash would eat, so normalize the separators
+        # before resolving.
+        SDK_IN="${{ inputs.score-sdk-path }}"
+        SCORE_SDK="$(cd "${SDK_IN//\\//}" && pwd)"
         cmake -S ${{ inputs.addon-path }} -B ${{ env.BUILD_DIR }} \
-          -DCMAKE_MODULE_PATH=$PWD/${{ inputs.score-sdk-path }}/lib/cmake/score \
-          -DSCORE_SDK=$PWD/${{ inputs.score-sdk-path }} \
+          -DCMAKE_MODULE_PATH="$SCORE_SDK/lib/cmake/score" \
+          -DSCORE_SDK="$SCORE_SDK" \
           -DOSSIA_SDK=${{ inputs.ossia-sdk-path }} \
           -DCMAKE_BUILD_TYPE=${{ inputs.build-type }} \
           -DCMAKE_UNITY_BUILD=1 \

--- a/jit-compile/action.yml
+++ b/jit-compile/action.yml
@@ -55,7 +55,9 @@ runs:
         else
           DOWNLOAD_URL="https://github.com/ossia/score/releases/download/v${{ steps.version.outputs.version }}/${{ steps.score-filename.outputs.filename }}"
         fi
-        curl -L -O "$DOWNLOAD_URL"
+        # -f so a renamed or missing asset fails here, instead of writing a
+        # short HTML error body that only blows up later in unzip/hdiutil.
+        curl -fL -O "$DOWNLOAD_URL"
 
     - name: Install score (macOS)
       if: runner.os == 'macOS'
@@ -74,14 +76,25 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        sudo apt -y install xvfb libasound2t64 libxcb1 libegl1 libgl1-mesa-dev libegl1-mesa-dev libglvnd0 libx11-6 libxcb-glx0 libgl1 libdbus-1-3 libxcb-xkb1 libxkbcommon-x11-0 libxcb-xkb1 libfuse2
+        # libv4l-0 and libbluetooth3 are required by the score AppImage itself:
+        # without them it aborts at startup with "MISSING LIBRARY!" before the
+        # addon is ever compiled.
+        sudo apt -y install xvfb libasound2t64 libxcb1 libegl1 libgl1-mesa-dev libegl1-mesa-dev libglvnd0 libx11-6 libxcb-glx0 libgl1 libdbus-1-3 libxcb-xkb1 libxkbcommon-x11-0 libxcb-xkb1 libfuse2 libv4l-0 libbluetooth3
         chmod +x ${{ steps.score-filename.outputs.filename }}
 
     - name: Set SDK path
       if: inputs.sdk-path != ''
       shell: bash
       run: |
-        echo "SCORE_JIT_SDK=$(realpath ${{ inputs.sdk-path }})" >> $GITHUB_ENV
+        # The path may be relative (./sdk/usr) or absolute; on Windows an
+        # absolute one arrives with backslashes, which bash would eat and
+        # realpath would then fail to resolve, silently leaving the variable
+        # empty. Normalize the separators, then resolve.
+        # Assign first: inlining the substitution into echo would let a failed
+        # resolve write an empty value and keep going.
+        SDK_IN="${{ inputs.sdk-path }}"
+        SDK_ABS="$(cd "${SDK_IN//\\//}" && pwd)"
+        echo "SCORE_JIT_SDK=$SDK_ABS" >> $GITHUB_ENV
 
     - name: Set environment
       shell: bash


### PR DESCRIPTION
Four fixes in the shared actions that between them account for most of the currently-red addon CI.

### `build-addon`: `$PWD/` prefixed onto absolute paths

`Configure (SDK build)` and `Configure (dev build)` unconditionally prefixed `$PWD/`. That is fine for the reusable workflows, which pass a relative `./sdk`, but the seven addons still carrying inlined workflow copies pass `${{ runner.temp }}/sdk`, producing:

```
-DSCORE_SDK=$PWD//home/runner/work/_temp/sdk/usr
```

`SCORE_SDK` then resolves empty inside CMake and configure dies with `include could not find requested file: ScoreExternalAddon`, cascading into `Unknown CMake command "score_common_setup"`. On Windows it was worse — bash ate the backslashes in `D:\a\_temp`, giving `-DCMAKE_MODULE_PATH=$PWD/D:\a\_temp/sdk/usr/lib/cmake/score`.

Now the path is resolved rather than concatenated, with separators normalized first. Relative, absolute and Windows-backslash forms all work. This also removes the leftover `find` debug spam that scanned the entire SDK on every configure.

### `jit-compile`: `realpath` on a Windows path

Same class of bug: `realpath: 'D:a_temp/sdk/usr': No such file or directory`, leaving `SCORE_JIT_SDK` empty. The value is now assigned before being written to `$GITHUB_ENV`, so a failed resolve fails the step instead of silently writing an empty variable.

### `jit-compile`: missing runtime libs

The score AppImage needs `libv4l-0` and `libbluetooth3`, and aborts at startup without them:

```
libv4l2.so.0: MISSING LIBRARY!
libbluetooth.so.3: MISSING LIBRARY!
ossia-score: error while loading shared libraries: libv4l2.so.0: cannot open shared object file
```

On some runners this hangs to the 10-minute job timeout rather than failing outright.

### `jit-compile`: `curl` without `-f`

A 404 wrote a 9-byte `Not Found` body and exited 0, so a renamed release asset only surfaced much later as `End-of-central-directory signature not found` from unzip, or `hdiutil` exit 1. Now it fails at the download step.

### `builds-sdk`: missing `libgbm-dev`

`builds-dev` already installs it; `builds-sdk` did not. `Qt6EglFsKmsGbmSupportPrivate` does `find_dependency` on `gbm`, so without the dev package the log shows `Could NOT find gbm (missing: gbm_LIBRARY gbm_INCLUDE_DIR)` and `find_package(Qt6Widgets)` then fails with `the link interface of target "Qt6::QEglFSKmsGbmIntegrationPlugin" contains Qt6::EglFsKmsGbmSupportPrivate but the target was not found`.

---

Not addressed here, tracked separately: the clang-21 intrinsic-header failures on the `latest` SDK channel (needs a score release newer than v3.8.2 — the fix landed in `0ae37fc4e3` on 2026-06-14), the JIT `./addon/<X>.hpp` include resolution, and the Windows `0xC000001D` startup crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)