### PR TITLE
ci: use upstream Apple-Actions/import-codesign-certs@v7

### DIFF
--- a/custom-score-build/action.yml
+++ b/custom-score-build/action.yml
@@ -66,7 +66,7 @@ runs:
       with:
         xcode-version: '>=16'
 
-    - uses: jcelerier/import-codesign-certs@master
+    - uses: Apple-Actions/import-codesign-certs@v7
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}

--- a/package-clap-addon/action.yml
+++ b/package-clap-addon/action.yml
@@ -61,7 +61,7 @@ runs:
   steps:
     - name: Import code signing certificate (macOS)
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-cmake-addon/action.yml
+++ b/package-cmake-addon/action.yml
@@ -102,7 +102,7 @@ runs:
       if: >-
         runner.os == 'macOS' && steps.detect.outputs.has-dir == 'true'
         && inputs.backend != 'pd' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-custom-app/action.yml
+++ b/package-custom-app/action.yml
@@ -179,7 +179,7 @@ runs:
 
     - name: Import code signing certificate (macOS)
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != '' && inputs.score-build-id == ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-godot-addon/action.yml
+++ b/package-godot-addon/action.yml
@@ -61,7 +61,7 @@ runs:
   steps:
     - name: Import code signing certificate (macOS)
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-gstreamer-addon/action.yml
+++ b/package-gstreamer-addon/action.yml
@@ -61,7 +61,7 @@ runs:
   steps:
     - name: Import code signing certificate (macOS)
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-max-addon/action.yml
+++ b/package-max-addon/action.yml
@@ -213,7 +213,7 @@ runs:
     # --- macOS signing & notarization (inline pattern) ---
     - name: Import macOS code signing certificate
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-python-addon/action.yml
+++ b/package-python-addon/action.yml
@@ -62,7 +62,7 @@ runs:
   steps:
     - name: Import code signing certificate (macOS)
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-standalone-addon/action.yml
+++ b/package-standalone-addon/action.yml
@@ -61,7 +61,7 @@ runs:
   steps:
     - name: Import code signing certificate (macOS)
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-touchdesigner-addon/action.yml
+++ b/package-touchdesigner-addon/action.yml
@@ -140,7 +140,7 @@ runs:
     # --- macOS signing & notarization (inline pattern) ---
     - name: Import macOS code signing certificate
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-vintage-addon/action.yml
+++ b/package-vintage-addon/action.yml
@@ -61,7 +61,7 @@ runs:
   steps:
     - name: Import code signing certificate (macOS)
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}

--- a/package-vst3-addon/action.yml
+++ b/package-vst3-addon/action.yml
@@ -61,7 +61,7 @@ runs:
   steps:
     - name: Import code signing certificate (macOS)
       if: runner.os == 'macOS' && inputs.macos-certificate-base64 != ''
-      uses: jcelerier/import-codesign-certs@master
+      uses: Apple-Actions/import-codesign-certs@v7
       with:
         p12-file-base64: ${{ inputs.macos-certificate-base64 }}
         p12-password: ${{ inputs.macos-certificate-password }}


### PR DESCRIPTION
Replaces `jcelerier/import-codesign-certs@master` with `Apple-Actions/import-codesign-certs@v7` at all 12 call sites.

## Why

The fork carries **no patches**. Against upstream `main` it is **0 commits ahead, 63 behind**; its `master` tip (`66e9087`, 2025-10-07) is itself an upstream commit; it has one branch and no tags. It's a plain sync-fork created 2024-04-11 that stopped being synced.

It also still declares `runs.using: node20`, so every macOS job in every project consuming these actions emits:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: … jcelerier/import-codesign-certs@master

Upstream moved to `node24` in **v6.0.0** (2025-12-02, which also allowed `productsign` — Apple-Actions/import-codesign-certs#131) and is now at **v7.0.0** (2026-04-21, `ncc` → `esbuild`, no interface change).

## Why it's safe

`action.yml` inputs and outputs are byte-identical between the pinned fork commit and upstream v7 — the only difference in the whole manifest is `using: node20` → `node24`. Every one of the 12 call sites passes exactly the same two inputs, `p12-file-base64` and `p12-password`, both unchanged. No call site sets `keychain`, `create-keychain`, or `keychain-password`, and none reads the action's outputs, so the auto-generated `signing_temp` keychain behaviour is untouched.

## Secondary benefit

`@master` is a mutable ref on a personal fork, for a step that receives a signing certificate and its password — any push to that fork silently changes what runs. A version tag on the upstream org is a smaller surface. (Pinning to a commit SHA would be stricter still; happy to do that instead if you'd prefer.)

## Files

`custom-score-build`, `package-custom-app`, and `package-{clap,cmake,godot,gstreamer,max,python,standalone,touchdesigner,vintage,vst3}-addon`.

Note this is 12 files, not the 10 GitHub code search reports — its index is missing `package-gstreamer-addon` and `package-standalone-addon`. The list above comes from a grep of a fresh clone.

## Verification

There's no CI in this repo that exercises the macOS signing path, and the certificate inputs are empty for forks, so this can't be proven green here. It's validated by the next signed macOS build in a consuming project — these actions are referenced at `@master`, so merging takes effect immediately for all of them. The first consumer to exercise it will be `sat-mtl/spatial-protocol-mapper` (sat-mtl/spatial-protocol-mapper#20 is bumping its own deprecated actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDpmynESrQrqCCKMuWNgYk