### PR TITLE
feat: build and package custom apps for WebAssembly

### DIFF
--- a/custom-score-build/action.yml
+++ b/custom-score-build/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Override target architecture: x86_64 or aarch64. If empty, inferred from RUNNER_ARCH. Use to cross-compile (e.g. Intel macOS on an ARM runner).'
     required: false
     default: ''
+  target-platform:
+    description: 'Target platform: empty builds for the runner itself, "wasm" cross-compiles to WebAssembly. wasm requires an ubuntu-24.04 runner, which is the image the wasm SDK is built on.'
+    required: false
+    default: ''
   macos-certificate-base64:
     description: 'Base64-encoded P12 certificate for macOS code signing (optional)'
     required: false
@@ -85,7 +89,13 @@ runs:
         fi
         export MACOS_ARCH=$CPU_ARCH
 
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
+        if [[ "$TARGET_PLATFORM" == "wasm" ]]; then
+          if [[ "$RUNNER_OS" != "Linux" ]]; then
+            echo "Error: target-platform: wasm needs a Linux runner (ubuntu-24.04), got $RUNNER_OS"
+            exit 1
+          fi
+          ./ci/wasm.deps.sh
+        elif [[ "$RUNNER_OS" == "Linux" ]]; then
           ./ci/appimage.deps.sh
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
           ./ci/win32.deps.sh
@@ -95,6 +105,7 @@ runs:
 
       env:
         TARGET_ARCH: ${{ inputs.target-arch }}
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
         MAC_CERT_B64: ${{ inputs.macos-certificate-base64 }}
         MAC_CODESIGN_PASSWORD:  ${{ inputs.macos-certificate-password }}
 
@@ -111,7 +122,9 @@ runs:
         fi
         export MACOS_ARCH=$CPU_ARCH
 
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
+        if [[ "$TARGET_PLATFORM" == "wasm" ]]; then
+          ./ci/wasm.build.sh
+        elif [[ "$RUNNER_OS" == "Linux" ]]; then
           ./ci/appimage.build.sh
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
           ./ci/win32.build.sh
@@ -120,6 +133,7 @@ runs:
         fi
       env:
         TARGET_ARCH: ${{ inputs.target-arch }}
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
         SCORE_EXTRA_CMAKE_ARGS: ${{ inputs.cmake-options }}
         SCORE_CMAKE_CACHE: ${{ inputs.cmake-cache }}
 
@@ -142,7 +156,21 @@ runs:
         export BUILD_ARTIFACTSTAGINGDIRECTORY="$PWD/staging"
         mkdir -p "$BUILD_ARTIFACTSTAGINGDIRECTORY"
 
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
+        if [[ "$TARGET_PLATFORM" == "wasm" ]]; then
+          BUNDLE="$PWD/wasm-bundle"
+          rm -rf "$BUNDLE"
+          mkdir -p "$BUNDLE"
+
+          cp /build/*.js "$BUNDLE/"
+          cp /build/ossia-score.wasm "$BUNDLE/"
+          if [[ -f /build/ossia-score.data ]]; then
+            cp /build/ossia-score.data "$BUNDLE/"
+          fi
+          cp cmake/Deployment/WASM/* "$BUNDLE/"
+
+          ( cd "$BUNDLE" && zip -r -q "$BUILD_ARTIFACTSTAGINGDIRECTORY/ossia.score-wasm.zip" . )
+          echo "release-name=wasm" >> $GITHUB_OUTPUT
+        elif [[ "$RUNNER_OS" == "Linux" ]]; then
           ./ci/appimage.deploy.sh
           echo "release-name=appimage-$CPU_ARCH" >> $GITHUB_OUTPUT
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -154,6 +182,7 @@ runs:
         fi
       env:
         TARGET_ARCH: ${{ inputs.target-arch }}
+        TARGET_PLATFORM: ${{ inputs.target-platform }}
         MAC_ALTOOL_PASSWORD: ${{ inputs.macos-notarize-password }}
 
     - name: Upload build

--- a/package-custom-app/action.yml
+++ b/package-custom-app/action.yml
@@ -70,7 +70,7 @@ inputs:
     required: false
     default: 'packages'
   platforms:
-    description: 'Space-separated list of platforms to build for (linux-x86_64 linux-aarch64 macos-intel macos-arm windows). If empty, builds for current platform.'
+    description: 'Space-separated list of platforms to build for (linux-x86_64 linux-aarch64 macos-intel macos-arm windows wasm). If empty, builds for current platform. wasm produces a static web bundle and needs a Linux runner; with score-build-id it expects a build made with custom-score-build target-platform: wasm.'
     required: false
     default: ''
   score-repo:
@@ -257,7 +257,14 @@ runs:
     - name: Create custom app packages
       shell: bash
       run: |
-        if [[ "$RUNNER_OS" == "Linux" ]]; then
+        if [[ " ${{ inputs.platforms }} " == *" wasm "* ]]; then
+          export SCORE_LOCAL_INSTALLER=score-build/*.zip
+
+          if [[ -n "${{ inputs.qrc-file }}" ]]; then
+            RCC_PATH=$(find .. -name rcc -type f)
+            export PATH="$PATH:$PWD/$(dirname $RCC_PATH)"
+          fi
+        elif [[ "$RUNNER_OS" == "Linux" ]]; then
           export SCORE_LOCAL_INSTALLER=score-build/*.AppImage
 
           if [[ -n "${{ inputs.qrc-file }}" ]]; then


### PR DESCRIPTION
`package-custom-app` already forwards `--platform wasm` to `create-app.sh`, but the combination could not actually work: whenever `score-build-id` is set the action passes `--local-installer score-build/*.AppImage`, and `create-app-wasm.sh` rejects anything that isn't a directory or a zip. wasm was therefore only reachable via `release-tag` — i.e. with *stock* score, no custom addons, which is the point of these builds.

## custom-score-build: `target-platform: wasm`

Runs `ci/wasm.deps.sh` + `ci/wasm.build.sh`, then assembles the layout `create-app-wasm.sh` expects — plain `ossia-score.wasm`, `ossia-score.js`, the optional `.data`, and the loader files from `cmake/Deployment/WASM` — and uploads it as a zip.

Deliberately **not** `ci/wasm.deploy.sh`: that one prepares the score-web checkout and gzips the binary, and `create-app-wasm.sh` needs the plain `.wasm`. The layout produced here matches the published `ossia.score-master-wasm.zip`.

wasm requires a Linux runner (ubuntu-24.04, the image the wasm SDK is built on); the action fails with a clear message otherwise rather than producing something broken.

> [!IMPORTANT]
> Depends on ossia/score#2155. Without it `ci/wasm.build.sh` ignores `SCORE_EXTRA_CMAKE_ARGS`, so the wasm build silently comes out as stock score no matter what `cmake-options` says.

## package-custom-app

Recognises wasm *before* branching on `RUNNER_OS` — wasm is a Linux runner emitting a web bundle, and its score build is a zip rather than an AppImage — and documents wasm in the `platforms` input.

## Usage

```yaml
- uses: ossia/actions/custom-score-build@master
  id: score
  with:
    target-platform: wasm          # needs runs-on: ubuntu-24.04
    cmake-options: -DSCORE_ENABLE_ADDONS=score-addon-spatgris
- uses: ossia/actions/package-custom-app@master
  with:
    platforms: wasm
    score-build-id: ${{ steps.score.outputs.artifact-id }}
    # ... app metadata
```

## Validation

The packaging half is verified end to end: I ran `create-app.sh --platform wasm` against a zip in exactly this layout (the published `ossia.score-master-wasm.zip`) and the bundle comes out with the app's QML, the score file, and a correct `preload.json`.

Both action files parse as YAML. The build half — the emscripten compile itself — is not something I could run locally; the first repo to adopt it will be the real test, and it fails loudly rather than silently if `/build/ossia-score.wasm` is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxtUwsfk4JN46WropbwfqC