### PR TITLE
fix: download the Windows installer under the name score publishes

### DIFF
--- a/jit-compile/action.yml
+++ b/jit-compile/action.yml
@@ -37,7 +37,12 @@ runs:
         fi
         
         if [[ "${{ runner.os }}" == "Windows" ]]; then
-          echo "filename=${PREFIX}-win64.exe" >> $GITHUB_OUTPUT
+          if [[ "${{ runner.arch }}" == "ARM64" ]]; then
+            WIN_ARCH=aarch64
+          else
+            WIN_ARCH=x86_64
+          fi
+          echo "filename=${PREFIX}-${WIN_ARCH}.exe" >> $GITHUB_OUTPUT
           echo "executable=./score.exe" >> $GITHUB_OUTPUT
         elif [[ "${{ runner.os }}" == "macOS" ]]; then
           echo "filename=${PREFIX}-macOS-AppleSilicon.dmg" >> $GITHUB_OUTPUT
@@ -55,7 +60,7 @@ runs:
         else
           DOWNLOAD_URL="https://github.com/ossia/score/releases/download/v${{ steps.version.outputs.version }}/${{ steps.score-filename.outputs.filename }}"
         fi
-        curl -L -O "$DOWNLOAD_URL"
+        curl -L -f -O "$DOWNLOAD_URL"
 
     - name: Install score (macOS)
       if: runner.os == 'macOS'


### PR DESCRIPTION
`jit-compile` asks for `ossia.score-<version>-win64.exe`. `ci/win32.deploy.sh` renamed its output per architecture a while back, so on `master`/`continuous` that name resolves to a **stale leftover asset** rather than the current build:

```
ossia.score-master-x86_64.exe   236MB  2026-07-27   <- current
ossia.score-master-win64.exe    235MB  2026-07-14   <- what this action downloads
```

Every JIT-compile run against `master`/`continuous` has been testing addons on a two-week-old score, and would break outright the day that asset is cleaned up.

Now uses `-x86_64.exe` / `-aarch64.exe`, picked from `runner.arch` — which also lets the action run on a Windows ARM64 runner.

Also adds `-f` to the download, so a missing asset fails at `curl` instead of leaving an HTML error page named like an installer for `7z` to choke on.

## Compatibility

The new names only, no fallback: releases up to v3.8.2 carry `-win64.exe` alone, so pinning `score-version` to one of those no longer resolves. Everything from the next tag onward uses the per-arch names.

## Validation

`continuous/ossia.score-master-x86_64.exe` → 200.

## Related

Same root cause as ossia/score#2156, which fixes `create-app-windows.sh` and adds the `windows-arm64` platform.

Two other places still use the old name, both still resolving today because they pin tags that predate the rename, and both breaking at the first tag cut after it:

- `ossia.github.io/_pages/score-download.md` — the public Windows download button
- `score-addon-{led,orbbec,pico,py,spat,synthimi}/.github/workflows/jit.yml` — `score: "win64.exe"` in their matrices

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxtUwsfk4JN46WropbwfqC
